### PR TITLE
Fix codespell hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,7 +32,7 @@ repos:
     rev: v2.3.0
     hooks:
       - id: codespell
-        args: [-L, .codespell_ignore.txt]
+        args: [-I, .codespell_ignore.txt]
         exclude: .*/static/.*/js/.*
   - repo: https://github.com/djlint/djLint
     rev: v1.35.2


### PR DESCRIPTION
It turns out that -L lets you provide a list of words to ignore on the command line. What we actually want is to provide a file with a list of words to be ignored. The correct option for this is -I.

See: https://github.com/ImperialCollegeLondon/python-template/pull/137