### PR TITLE
Add Django GroupMember model to represent research groups directly.

### DIFF
--- a/imperial_coldfront_plugin/models.py
+++ b/imperial_coldfront_plugin/models.py
@@ -1,1 +1,28 @@
 """Plugin Django models."""
+
+from django.conf import settings
+from django.contrib.auth.models import User
+from django.db import models
+
+
+class GroupMember(models.Model):
+    """Membership relationship within a group, associating an owner with a member.
+
+    This model stores relationships where each instance represents an ownership
+    connection between two users within a group, where `owner` is the user who
+    owns the membership (or perhaps manages the group) and `member` is the
+    associated user.
+
+    Attributes:
+        owner (ForeignKey): A reference to the user designated as owner, connected to
+            AUTH_USER_MODEL. Deletes related memberships when the owner is deleted.
+        member (ForeignKey): A reference to the user designated as member, connected to
+            AUTH_USER_MODEL. Deletes related memberships when the member is deleted.
+    """
+
+    owner: User = models.ForeignKey(settings.AUTH_USER_MODEL, on_delete=models.CASCADE)
+    member: User = models.ForeignKey(settings.AUTH_USER_MODEL, on_delete=models.CASCADE)
+
+    def __str__(self) -> str:
+        """Returns a string representation of the GroupMember instance."""
+        return f"Group owner is: {self.owner}\n - Group member is: {self.member}"

--- a/imperial_coldfront_plugin/models.py
+++ b/imperial_coldfront_plugin/models.py
@@ -1,7 +1,6 @@
 """Plugin Django models."""
 
 from django.conf import settings
-from django.contrib.auth.models import User
 from django.db import models
 
 
@@ -20,9 +19,5 @@ class GroupMember(models.Model):
             AUTH_USER_MODEL. Deletes related memberships when the member is deleted.
     """
 
-    owner: User = models.ForeignKey(settings.AUTH_USER_MODEL, on_delete=models.CASCADE)
-    member: User = models.ForeignKey(settings.AUTH_USER_MODEL, on_delete=models.CASCADE)
-
-    def __str__(self) -> str:
-        """Returns a string representation of the GroupMember instance."""
-        return f"Group owner is: {self.owner}\n - Group member is: {self.member}"
+    owner = models.ForeignKey(settings.AUTH_USER_MODEL, on_delete=models.CASCADE)
+    member = models.ForeignKey(settings.AUTH_USER_MODEL, on_delete=models.CASCADE)


### PR DESCRIPTION
# Description

- Introduces a new `GroupMember` model to provide a direct representation of research groups.
- Adds `owner` and `member` fields as ForeignKey references to the user model, designating a group owner and associated member.
- This initial implementation lays the groundwork for expanding research group functionality in future updates.

Notes to reviewers:
- Please verify that the `on_delete` behaviour is appropriate for the use case.
- Migrations are not yet included, as `django manage.py` is currently unavailable.

Fixes #17 

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [x] All tests pass (eg. `python -m pytest`)
- [ ] The documentation builds and looks OK (eg. `python -m sphinx -b html docs docs/build`)
- [x] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
