### PR TITLE
Uid from ldap

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,7 @@ jobs:
         with:
           python-version: ${{matrix.python-version}}
           cache: pip
+      - run: sudo apt-get update && sudo apt-get install -y libldap2-dev libsasl2-dev libssl-dev
       - name: Install dependencies
         run: pip install -r dev-requirements.txt && pip install -e .
 

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -154,6 +154,12 @@ pluggy==1.5.0
     # via pytest
 pre-commit==4.0.1
     # via imperial_coldfront_plugin (pyproject.toml)
+pyasn1==0.6.1
+    # via
+    #   pyasn1-modules
+    #   python-ldap
+pyasn1-modules==0.4.1
+    # via python-ldap
 pycparser==2.22
     # via cffi
 pyopenssl==24.2.1
@@ -186,6 +192,8 @@ python-dateutil==2.9.0.post0
     #   arrow
     #   coldfront
     #   faker
+python-ldap==3.4.4
+    # via imperial_coldfront_plugin (pyproject.toml)
 python-memcached==1.62
     # via coldfront
 pytz==2024.1

--- a/doc-requirements.txt
+++ b/doc-requirements.txt
@@ -185,6 +185,12 @@ platformdirs==4.3.6
     # via
     #   mkdocs-get-deps
     #   mkdocstrings
+pyasn1==0.6.1
+    # via
+    #   pyasn1-modules
+    #   python-ldap
+pyasn1-modules==0.4.1
+    # via python-ldap
 pycparser==2.22
     # via cffi
 pygments==2.18.0
@@ -205,6 +211,8 @@ python-dateutil==2.9.0.post0
     #   coldfront
     #   faker
     #   ghp-import
+python-ldap==3.4.4
+    # via imperial_coldfront_plugin (pyproject.toml)
 python-memcached==1.62
     # via coldfront
 pytz==2024.1

--- a/imperial_coldfront_plugin/ldap.py
+++ b/imperial_coldfront_plugin/ldap.py
@@ -1,0 +1,23 @@
+"""Module for interacting with LDAP identity provider."""
+
+import ldap
+from django.conf import settings
+
+
+def get_uid_from_ldap(username: str) -> int:
+    """Retrieve the UID from LDAP for a given username.
+
+    Args:
+      username: The username to search for in LDAP.
+
+    Returns:
+      The UID number associated with the given username.
+    """
+    conn = ldap.initialize(settings.LDAP_SERVER_URI)
+    conn.set_option(ldap.OPT_REFERRALS, 0)
+    conn.set_option(ldap.OPT_PROTOCOL_VERSION, 3)
+    conn.set_option(ldap.OPT_X_TLS_REQUIRE_CERT, ldap.OPT_X_TLS_ALLOW)
+    result = conn.search_s(
+        settings.LDAP_SEARCH_BASE, ldap.SCOPE_SUBTREE, f"(cn={username})", ["uidNumber"]
+    )
+    return int(result[0][1]["uidNumber"][0].decode("utf-8"))

--- a/imperial_coldfront_plugin/oidc.py
+++ b/imperial_coldfront_plugin/oidc.py
@@ -1,21 +1,34 @@
 """Customisations for the OIDC authentication backend."""
 
+import logging
 from typing import Any
 
+from django.conf import settings
 from django.contrib.auth.models import User
 from mozilla_django_oidc.auth import OIDCAuthenticationBackend
 
+from .ldap import get_uid_from_ldap
+from .models import UnixUID
 
-def _update_user(user: User, claims: dict[str, Any]) -> None:
-    user.username = claims["preferred_username"].rstrip("@ic.ac.uk")
-    user.email = claims["email"]
-    user.first_name = claims["given_name"]
-    user.last_name = claims["family_name"]
-    user.save()
+logger = logging.getLogger("django")
 
 
 class ICLOIDCAuthenticationBackend(OIDCAuthenticationBackend):
     """Extension of the OIDC authentication backend for ICL auth."""
+
+    def _get_user_data_from_claims(self, claims: dict[str, Any]) -> dict[str, str]:
+        return dict(
+            username=claims["preferred_username"].rstrip("@ic.ac.uk"),
+            email=claims["email"],
+            first_name=claims["given_name"],
+            last_name=claims["family_name"],
+        )
+
+    def _update_user_from_dict(self, user: User, data: dict[str, str]) -> None:
+        user.username = data["username"]
+        user.email = data["email"]
+        user.first_name = data["first_name"]
+        user.last_name = data["last_name"]
 
     def create_user(self, claims: dict[str, Any]) -> User:
         """Create a new user from the available claims.
@@ -23,8 +36,26 @@ class ICLOIDCAuthenticationBackend(OIDCAuthenticationBackend):
         Args:
           claims: user info provided by self.get_user_info
         """
+        user_data = self._get_user_data_from_claims(claims)
+        username = user_data["username"]
+        if settings.LDAP_SERVER_URI and settings.LDAP_SEARCH_BASE:
+            try:
+                uid = get_uid_from_ldap(username)
+            except Exception:
+                raise ValueError(
+                    f"Failed to retrieve UID from LDAP for user {username}"
+                )
+        else:
+            uid = None
+            logger.warn(
+                f"LDAP settings not configured, UID not retrieved for user {username}"
+            )
+
         user = super().create_user(claims)
-        _update_user(user, claims)
+        self._update_user_from_dict(user, user_data)
+        user.save()
+        if uid is not None:
+            UnixUID.objects.create(user=user, identifier=uid)
         return user
 
     def update_user(self, user: User, claims: dict[str, Any]) -> User:
@@ -34,7 +65,8 @@ class ICLOIDCAuthenticationBackend(OIDCAuthenticationBackend):
           user: user to update
           claims: user info provided by self.get_user_info
         """
-        _update_user(user, claims)
+        user_data = self._get_user_data_from_claims(claims)
+        self._update_user_from_dict(user, user_data)
         return user
 
     def get_userinfo(

--- a/imperial_coldfront_plugin/settings.py
+++ b/imperial_coldfront_plugin/settings.py
@@ -1,0 +1,6 @@
+"""Plugin settings that are imported into the global settings namespace of Coldfront."""
+
+from coldfront.config.env import ENV
+
+LDAP_SERVER_URI = ENV.str("LDAP_SERVER_URI", default="")
+LDAP_SEARCH_BASE = ENV.str("LDAP_SEARCH_BASE", default="")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,7 @@ module = "tests.*"
 disallow_untyped_defs = false
 
 [[tool.mypy.overrides]]
-module = ["mozilla_django_oidc.*", "ldap.*"]
+module = ["mozilla_django_oidc.*", "ldap.*", "coldfront.*"]
 ignore_missing_imports = true
 
 [[tool.mypy.overrides]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
     "django",
     "mozilla_django_oidc",
     "django-stubs-ext",
+    "python-ldap",
 ]
 
 [project.optional-dependencies]
@@ -60,7 +61,7 @@ module = "tests.*"
 disallow_untyped_defs = false
 
 [[tool.mypy.overrides]]
-module = ["mozilla_django_oidc.*"]
+module = ["mozilla_django_oidc.*", "ldap.*"]
 ignore_missing_imports = true
 
 [[tool.mypy.overrides]]
@@ -92,4 +93,4 @@ pydocstyle.convention = "google"
 ] # Missing docstring in public module, Missing docstring in public package
 
 [tool.django-stubs]
-django_settings_module = "imperial_coldfront_plugin" # a lie but seems to satisfy
+django_settings_module = "imperial_coldfront_plugin.settings"

--- a/requirements.txt
+++ b/requirements.txt
@@ -108,6 +108,12 @@ josepy==1.14.0
     # via mozilla-django-oidc
 mozilla-django-oidc==4.0.1
     # via imperial_coldfront_plugin (pyproject.toml)
+pyasn1==0.6.1
+    # via
+    #   pyasn1-modules
+    #   python-ldap
+pyasn1-modules==0.4.1
+    # via python-ldap
 pycparser==2.22
     # via cffi
 pyopenssl==24.2.1
@@ -121,6 +127,8 @@ python-dateutil==2.9.0.post0
     #   arrow
     #   coldfront
     #   faker
+python-ldap==3.4.4
+    # via imperial_coldfront_plugin (pyproject.toml)
 python-memcached==1.62
     # via coldfront
 pytz==2024.1


### PR DESCRIPTION
# Description

This pull request introduces LDAP integration to the allow retrieving and storing unix uid values for users.

User uid values are retrieved during the user creation process by the OIDC authentication backend provided by `imperial_coldfront_plugin.oidc.ICLOIDCAuthenticationBackend`. If the necessary settings for the LDAP server are present then the user's uid is retrieved from `unixldap.cc.ic.ac.uk`. If the uid cannot be retrieved then user creation is aborted. If the uid is successfully retrieved then a `UnixUID` instance is created to store the uid.

The uid retrieval process is tied to the OIDC authentication method as an underlying assumption is that the user must correspond to valid Imperial user in order for data to exist on the LDAP server.

The LDAP package used adds some additional OS requirements so a corresponding PR has been created for the development environment - imperialcollegelondon/coldfront_development_environment#2. You must use the branch from that PR to test this code.

Another requirement for trying this code out is that the OIDC authentication mechanism must be used. This is supported by the development environment but requires the correct environment variables to be set. I suggest we have a dedicated session to set these up for everybody. You can still create and login with local users (added via command line or the Django admin interface) but these will not have an associated UID value. Later on this will impose some limitations on what can be done with those users but `UnixUID` values can always be added manually.

To test:
- checkout the `ldap-support` branch of the development environment.
- checkout this branch in the submodule.
- make sure you have the appropriate environment variables set for OIDC - if done you will see "Log in via OpenID Connect" as an option.
- make sure you are on the College VPN or ZScaler
- start the app and log in using OIDC
- open a shell `docker compose exec app coldfront shell` and check a UnixUID instance was created for your user, e.g.:
```python
from imperial_coldfront_plugin.models import UnixUID
UnixUID.objects.get(user__username="yourusername")
```
on success a UnixUID will be successfully retrieved.

Fixes #33 

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [ ] All tests pass (eg. `python -m pytest`)
- [ ] The documentation builds and looks OK (eg. `python -m sphinx -b html docs docs/build`)
- [ ] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
