### PR TITLE
Dependency upgrade action

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,10 +5,6 @@
 
 version: 2
 updates:
-  - package-ecosystem: pip
-    directory: /
-    schedule:
-      interval: weekly
   - package-ecosystem: github-actions
     directory: /
     schedule:

--- a/.github/workflows/upgrade-dependencies.yml
+++ b/.github/workflows/upgrade-dependencies.yml
@@ -1,7 +1,6 @@
 name: Dependabot and Pre-commit auto-merge
 
 on:
-  push:
   schedule:
     - cron: 0 0 * * 1   # midnight every Monday
 

--- a/.github/workflows/upgrade-dependencies.yml
+++ b/.github/workflows/upgrade-dependencies.yml
@@ -1,6 +1,7 @@
 name: Dependabot and Pre-commit auto-merge
 
 on:
+  push:
   schedule:
     - cron: 0 0 * * 1   # midnight every Monday
 

--- a/.github/workflows/upgrade-dependencies.yml
+++ b/.github/workflows/upgrade-dependencies.yml
@@ -1,0 +1,47 @@
+name: Dependabot and Pre-commit auto-merge
+
+on:
+  schedule:
+    - cron: 0 0 * * 1   # midnight every Monday
+
+permissions:
+  contents: write
+  pull-requests: write # Needed if in a private repository
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: 3.11
+          cache: pip
+
+      - name: Install dependencies
+        run: pip install -U pip pip-tools
+
+      - name: Upgrade dependencies
+        run: |
+          pip-compile --upgrade
+          pip-compile --upgrade --extra=dev --output-file=dev-requirements.txt
+          pip-compile --upgrade --extra=doc --output-file=doc-requirements.txt
+
+      - name: Check file consistency
+        run: |
+          pip-sync --dry-run requirements.txt dev-requirements.txt doc-requirements.txt
+
+          # An exit code of 1 means there are changes but the files are consistent
+          if [ $? == 1 ]; then
+            exit 0
+          fi
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v7.0.5
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          branch: upgrade/python-dependencies
+          title: Upgrade python dependencies
+          commit-message: ':arrow_up: Upgrade Python dependencies with pip-compile'
+          body: Upgrade versions of Python dependencies to latest version using `pip-compile --upgrade`.

--- a/.github/workflows/upgrade-dependencies.yml
+++ b/.github/workflows/upgrade-dependencies.yml
@@ -30,13 +30,7 @@ jobs:
           pip-compile --upgrade --extra=doc --output-file=doc-requirements.txt
 
       - name: Check file consistency
-        run: |
-          pip-sync --dry-run requirements.txt dev-requirements.txt doc-requirements.txt
-
-          # An exit code of 1 means there are changes but the files are consistent
-          if [ $? == 1 ]; then
-            exit 0
-          fi
+        run: pip-sync requirements.txt dev-requirements.txt doc-requirements.txt
 
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v7.0.5

--- a/.github/workflows/upgrade-dependencies.yml
+++ b/.github/workflows/upgrade-dependencies.yml
@@ -1,4 +1,4 @@
-name: Dependabot and Pre-commit auto-merge
+name: Upgrade Python Dependencies with pip-compile
 
 on:
   schedule:
@@ -9,7 +9,7 @@ permissions:
   pull-requests: write # Needed if in a private repository
 
 jobs:
-  auto-merge:
+  upgrade-dependencies:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
# Description

This PR implements a custom action to upgrade the dependencies and open a PR using `pip-compile` directly instead of dependabot's `pip` option. This respects the restrictions in `pyproject.toml` and ensure the secondary dependencies are consistent with the primary ones.

I tested this by running it on `push`, which can be seen in , and resulted in PR #44 

Limitations:
- The CI workflows do not run in the resultant PR, to fix this we should use the RSE CI bot (see [these docs](https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#triggering-further-workflow-runs))
- If we want these to auto-merge, we will need to add the appropriate PR user to the `auto-merge.yml` workflow

Fixes #29 

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [ ] All tests pass (eg. `python -m pytest`)
- [ ] The documentation builds and looks OK (eg. `python -m sphinx -b html docs docs/build`)
- [ ] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
