### PR TITLE
Get user uids from Microsoft Graph API

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -200,6 +200,7 @@ requests==2.31.0
     # via
     #   coldfront
     #   doi2bib
+    #   imperial_coldfront_plugin (pyproject.toml)
     #   mozilla-django-oidc
 ruff==0.8.1
     # via imperial_coldfront_plugin (pyproject.toml)

--- a/doc-requirements.txt
+++ b/doc-requirements.txt
@@ -227,6 +227,7 @@ requests==2.31.0
     # via
     #   coldfront
     #   doi2bib
+    #   imperial_coldfront_plugin (pyproject.toml)
     #   mkdocs-material
     #   mozilla-django-oidc
 six==1.16.0

--- a/imperial_coldfront_plugin/oidc.py
+++ b/imperial_coldfront_plugin/oidc.py
@@ -10,7 +10,7 @@ from .models import UnixUID
 
 
 def _update_user(user: User, claims: dict[str, Any]) -> None:
-    user.username = claims["preferred_username"].rstrip("@ic.ac.uk")
+    user.username = claims["preferred_username"].removesuffix("@ic.ac.uk")
     user.email = claims["email"]
     user.first_name = claims["given_name"]
     user.last_name = claims["family_name"]

--- a/imperial_coldfront_plugin/oidc.py
+++ b/imperial_coldfront_plugin/oidc.py
@@ -8,6 +8,14 @@ from mozilla_django_oidc.auth import OIDCAuthenticationBackend
 
 from .models import UnixUID
 
+ENTRA_UID_ENDPOINT = (
+    "https://graph.microsoft.com/v1.0/me?$select=onPremisesExtensionAttributes"
+)
+"""URL for the Microsoft Graph API endpoint to retrieve the user's uid."""
+
+ENTRA_UID_ATTRIBUTE = "extensionAttribute12"
+"""Attribute name for the user's uid in the Microsoft Graph API response."""
+
 
 def _update_user(user: User, claims: dict[str, Any]) -> None:
     user.username = claims["preferred_username"].removesuffix("@ic.ac.uk")
@@ -61,10 +69,10 @@ class ICLOIDCAuthenticationBackend(OIDCAuthenticationBackend):
         # get user uid from Microsoft Graph API using the access token
         # uid is stored under a custom attribute
         response = requests.get(
-            "https://graph.microsoft.com/v1.0/me?$select=onPremisesExtensionAttributes",
+            ENTRA_UID_ENDPOINT,
             headers={"Authorization": f"Bearer {access_token}"},
         ).json()
         user_info["uid"] = int(
-            response["onPremisesExtensionAttributes"]["extensionAttribute12"]
+            response["onPremisesExtensionAttributes"][ENTRA_UID_ATTRIBUTE]
         )
         return user_info

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
     "django",
     "mozilla_django_oidc",
     "django-stubs-ext",
+    "requests",
 ]
 
 [project.optional-dependencies]

--- a/requirements.txt
+++ b/requirements.txt
@@ -133,6 +133,7 @@ requests==2.31.0
     # via
     #   coldfront
     #   doi2bib
+    #   imperial_coldfront_plugin (pyproject.toml)
     #   mozilla-django-oidc
 six==1.16.0
     # via


### PR DESCRIPTION
# Description

The original plan was to get uid values from LDAP but after discussion with the identity team they were able to add the uid data to the user data stored in Azure. That means we can now retrieve uid values from the Microsoft Entra Graph API user the access token from the login workflow. This has a number advantages over the previous LDAP implementation:

- simplicity (compare this PR with #42)
- no extra dependencies
- uses only 1 source for all identity data
- no additional settings

To test this:

- Clear the development database (`docker compose down -v`).
- Make sure the main branch of the development environment is up to date.
- Make sure you have the OIDC environment variables set.
- Start the server and login via the browser and Imperial SSO.
- Open a shell `docker compose exec app coldfront shell` and check a UnixUID instance was created for your user, e.g.:

```python
from imperial_coldfront_plugin.models import UnixUID
UnixUID.objects.get(user__username="yourusername")
```

Fixes #42 

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [X] All tests pass (eg. `python -m pytest`)
- [ ] The documentation builds and looks OK (eg. `python -m sphinx -b html docs docs/build`)
- [X] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
