### PR TITLE
Send emails in background

### DIFF
--- a/imperial_coldfront_plugin/utils.py
+++ b/imperial_coldfront_plugin/utils.py
@@ -5,7 +5,7 @@ from django.core.mail import send_mail
 from django_q.tasks import async_task
 
 
-def send_email_in_background(to_addresses, subject, body):
+def send_email_in_background(to_addresses: list[str], subject: str, body: str):
     """Wraps Django email functionality to send emails via a Django Q task.
 
     Args:

--- a/imperial_coldfront_plugin/utils.py
+++ b/imperial_coldfront_plugin/utils.py
@@ -1,0 +1,23 @@
+"""Helper functions."""
+
+from django.conf import settings
+from django.core.mail import send_mail
+from django_q.tasks import async_task
+
+
+def send_email_in_background(to_addresses, subject, body):
+    """Wraps Django email functionality to send emails via a Django Q task.
+
+    Args:
+        to_addresses: A list of email addresses to send the email to.
+        subject: The subject of the email.
+        body: The body of the email.
+    """
+    async_task(
+        send_mail,
+        subject,
+        body,
+        settings.DEFAULT_FROM_EMAIL,
+        to_addresses,
+        timeout=(settings.EMAIL_TIMEOUT or 0) + 1,
+    )

--- a/imperial_coldfront_plugin/views.py
+++ b/imperial_coldfront_plugin/views.py
@@ -118,7 +118,7 @@ def send_group_invite(request: HttpRequest) -> HttpResponse:
                 [invitee_email],
                 "HPC Access Invitation",
                 "You've been invited to join the access group of "
-                f"{request.user.get_full_name()}\n\n"
+                f"{request.user.get_full_name()} ({request.user.email})\n\n"
                 f"Click the following link to accept the invitation:\n{invite_url}",
             )
 

--- a/imperial_coldfront_plugin/views.py
+++ b/imperial_coldfront_plugin/views.py
@@ -3,7 +3,6 @@
 from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.contrib.auth.decorators import login_required
-from django.core.mail import send_mail
 from django.core.signing import BadSignature, SignatureExpired, TimestampSigner
 from django.http import (
     HttpRequest,
@@ -16,6 +15,7 @@ from django.urls import reverse
 
 from .forms import GroupMembershipForm, TermsAndConditionsForm
 from .models import GroupMembership, ResearchGroup
+from .utils import send_email_in_background
 
 User = get_user_model()
 
@@ -114,13 +114,12 @@ def send_group_invite(request: HttpRequest) -> HttpResponse:
             invite_url = request.build_absolute_uri(
                 reverse("imperial_coldfront_plugin:accept_group_invite", args=[token])
             )
-
-            # Send invitation via email.
-            send_mail(
-                "You've been invited to a group",
-                f"Click the following link to accept the invitation:\n{invite_url}",
-                request.user.email,
+            send_email_in_background(
                 [invitee_email],
+                "HPC Access Invitation",
+                "You've been invited to join the access group of "
+                f"{request.user.get_full_name()}\n\n"
+                f"Click the following link to accept the invitation:\n{invite_url}",
             )
 
     else:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -51,6 +51,7 @@ def pytest_configure():
             "django.contrib.auth.middleware.AuthenticationMiddleware",
         ],
         TOKEN_TIMEOUT=60,
+        Q_CLUSTER={"sync": True},
         **{
             key: getattr(plugin_settings, key)
             for key in dir(plugin_settings)

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -113,7 +113,7 @@ class TestSendGroupInviteView(LoginRequiredMixin):
         assert f"Invitation sent to {invitee_email}" in response.content.decode()
 
         email = mailoutbox[0]
-        assert email.subject == "You've been invited to a group"
+        assert email.subject == "HPC Access Invitation"
         assert email.to == [invitee_email]
         token = timestamp_signer_mock().sign_object.return_value
         assert (


### PR DESCRIPTION
# Description

Implements a wrapper function to make it simple to send emails as a background task and refactors the one view that sends emails already.

I've added a configuration for Django Q to the development environment so make sure you've got the latest `main` if you want to run it locally.

Fixes #89 

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [ ] All tests pass (eg. `python -m pytest`)
- [ ] The documentation builds and looks OK (eg. `python -m sphinx -b html docs docs/build`)
- [ ] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
