### PR TITLE
Remove xfails

### DIFF
--- a/imperial_coldfront_plugin/templates/no_group.html
+++ b/imperial_coldfront_plugin/templates/no_group.html
@@ -1,1 +1,10 @@
-<h1>{{ message }}</h1>
+{% extends "common/base.html" %}
+{% block content %}
+  <div class="container">
+    <div class="row">
+      <div class="col-md-12">
+        <h1>{{ message }}</h1>
+      </div>
+    </div>
+  </div>
+{% endblock content %}

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -50,7 +50,6 @@ class TestGroupMembersView(LoginRequiredMixin):
         assert response.status_code == HTTPStatus.FORBIDDEN
         assert response.content == b"Permission denied"
 
-    @pytest.mark.xfail(reason="This test is expected to fail due to a bug in the code.")
     def test_superuser(self, auth_client_factory, research_group_factory, user_factory):
         """Test that a superuser can access the view for any group."""
         owner = user_factory(is_pi=True)
@@ -67,7 +66,6 @@ class TestGroupMembersView(LoginRequiredMixin):
         assert response.status_code == HTTPStatus.OK
         assert response.context["message"] == "You do not own a group."
 
-    @pytest.mark.xfail(reason="This test is expected to fail due to a bug in the code.")
     def test_owner(self, auth_client_factory, research_group_factory):
         """Test that the pi that owns a group can access the view."""
         group, memberships = research_group_factory(number_of_members=3)


### PR DESCRIPTION
# Description

Fixes #47 

The bug was already fixed so this PR just removes the xfails that were left over. I was under the impression that pytest would flag an xfail marked test if it did not fail.

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [ ] All tests pass (eg. `python -m pytest`)
- [ ] The documentation builds and looks OK (eg. `python -m sphinx -b html docs docs/build`)
- [ ] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
