### PR TITLE
Member terms conditions

### DIFF
--- a/imperial_coldfront_plugin/forms.py
+++ b/imperial_coldfront_plugin/forms.py
@@ -7,3 +7,13 @@ class GroupMembershipForm(forms.Form):
     """Form for inviting a user to a research group."""
 
     invitee_email = forms.EmailField(label="Email")
+
+
+class TermsAndConditionsForm(forms.Form):
+    """Form for accepting terms and conditions."""
+
+    accept = forms.BooleanField(
+        label="I accept the terms and conditions",
+        required=True,
+        error_messages={"required": "You must accept the terms and conditions"},
+    )

--- a/imperial_coldfront_plugin/templates/imperial_coldfront_plugin/member_terms_and_conditions.html
+++ b/imperial_coldfront_plugin/templates/imperial_coldfront_plugin/member_terms_and_conditions.html
@@ -1,0 +1,13 @@
+{% extends "common/base.html" %}
+{% block content %}
+  By accepting this invitation you
+  will gain access to the Imperial College London HPC facilities. As a user of the service
+  you are expected to act responsibly and abide by the following terms and conditions:
+  <ul>
+    <li>Be cool</li>
+  </ul>
+  <form method="post">
+    {% csrf_token %} {{ form.as_p }}
+    <button type="submit">Submit</button>
+  </form>
+{% endblock content %}

--- a/imperial_coldfront_plugin/views.py
+++ b/imperial_coldfront_plugin/views.py
@@ -14,7 +14,7 @@ from django.http import (
 from django.shortcuts import get_object_or_404, render
 from django.urls import reverse
 
-from .forms import GroupMembershipForm
+from .forms import GroupMembershipForm, TermsAndConditionsForm
 from .models import GroupMembership, ResearchGroup
 
 User = get_user_model()
@@ -152,12 +152,23 @@ def accept_group_invite(request: HttpRequest, token: str) -> HttpResponse:
             "The invite token is not associated with this email address."
         )
 
-    # Update group membership in the database.
     group = ResearchGroup.objects.get(owner__pk=invite["inviter_pk"])
-    GroupMembership.objects.get_or_create(group=group, member=request.user)
 
+    if request.method == "POST":
+        form = TermsAndConditionsForm(request.POST)
+        # Check if the user has accepted the terms and conditions.
+        if form.is_valid():
+            # Update group membership in the database.
+            GroupMembership.objects.get_or_create(group=group, member=request.user)
+            return render(
+                request=request,
+                template_name="imperial_coldfront_plugin/accept_group_invite.html",
+                context={"inviter": group.owner, "group": group.name},
+            )
+    else:
+        form = TermsAndConditionsForm()
     return render(
         request=request,
-        context={"inviter": group.owner, "group": group.name},
-        template_name="imperial_coldfront_plugin/accept_group_invite.html",
+        context={"inviter": group.owner, "group": group.name, "form": form},
+        template_name="imperial_coldfront_plugin/member_terms_and_conditions.html",
     )

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -6,8 +6,9 @@ import pytest
 from django.conf import settings
 from django.core.signing import TimestampSigner
 from django.shortcuts import reverse
+from pytest_django.asserts import assertTemplateUsed
 
-from imperial_coldfront_plugin.forms import GroupMembershipForm
+from imperial_coldfront_plugin.forms import GroupMembershipForm, TermsAndConditionsForm
 from imperial_coldfront_plugin.models import GroupMembership
 
 
@@ -172,13 +173,33 @@ class TestAcceptGroupInvite(LoginRequiredMixin):
         token = self._get_token(user.email, pi_group.owner.pk)
         response = user_client.get(self._get_url(token))
         assert response.status_code == HTTPStatus.OK
-        assert b"You have accepted a group invitation" in response.content
-        GroupMembership.objects.get(group=pi_group, member=user)
+        assertTemplateUsed(
+            response, "imperial_coldfront_plugin/member_terms_and_conditions.html"
+        )
+        assert isinstance(response.context["form"], TermsAndConditionsForm)
 
-    def test_get_valid_token_already_member(self, user_client, pi_group, user):
+    def test_post_invalid(self, user_client, pi_group, user):
+        """Test that view renders the form with errors when invalid data is posted."""
+        token = self._get_token(user.email, pi_group.owner.pk)
+        response = user_client.post(self._get_url(token), data={})
+        assert response.status_code == HTTPStatus.OK
+        assert response.context["form"].errors == {
+            "accept": ["You must accept the terms and conditions"]
+        }
+
+    def test_post_valid(self, user_client, pi_group, user):
+        """Test that the view adds the user to the group when valid data is posted."""
+        token = self._get_token(user.email, pi_group.owner.pk)
+        response = user_client.post(self._get_url(token), data={"accept": True})
+        assert response.status_code == HTTPStatus.OK
+        assertTemplateUsed(
+            response, "imperial_coldfront_plugin/accept_group_invite.html"
+        )
+
+    def test_post_valid_already_member(self, user_client, pi_group, user):
         """Test that the view doesn't duplicate group memberships."""
         token = self._get_token(user.email, pi_group.owner.pk)
-        user_client.get(self._get_url(token))
+        user_client.post(self._get_url(token), data={"accept": True})
         GroupMembership.objects.get(group=pi_group, member=user)
 
 


### PR DESCRIPTION
# Description

Fixes #77

Fairly straightforward implementation. Turned the `accept_group_invite` view into a typical form handling view. Getting the view returns a page with the terms and conditions. Posting it with valid data creates the group membership and renders the confirmation page.

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [X] All tests pass (eg. `python -m pytest`)
- [X] The documentation builds and looks OK (eg. `python -m sphinx -b html docs docs/build`)
- [X] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)

## Further checks

- [X] Code is commented, particularly in hard-to-understand areas
- [X] Tests added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
