### PR TITLE
Filter entities returned graph api based on user profile

### DIFF
--- a/imperial_coldfront_plugin/microsoft_graph_client.py
+++ b/imperial_coldfront_plugin/microsoft_graph_client.py
@@ -32,7 +32,7 @@ def _transform_profile_data(data):
         "company_name": data.get("companyName"),
         "user_type": data.get("userType"),
         "job_family": extension_attributes.get("extensionAttribute14"),
-        "employment_status": extension_attributes.get("extensionAttribute6"),
+        "entity_type": extension_attributes.get("extensionAttribute6"),
         "record_status": extension_attributes.get("extensionAttribute5"),
         "name": data.get("displayName"),
         "email": data.get("mail"),

--- a/imperial_coldfront_plugin/policy.py
+++ b/imperial_coldfront_plugin/policy.py
@@ -16,18 +16,16 @@ def user_eligible_for_hpc_access(user_profile):
     Imperial identity systems contain entries for non-human entities such as rooms and
     shared mailboxes that should be removed from consideration.
     """
-    if any(
+    return all(
         [
-            user_profile["user_type"] != "Member",
-            user_profile["record_status"] != "Live",
-            not _filter_entity_type(user_profile["entity_type"]),
+            user_profile["user_type"] == "Member",
+            user_profile["record_status"] == "Live",
+            _filter_entity_type(user_profile["entity_type"]),
             None
-            in [
+            not in (
                 user_profile["email"],
                 user_profile["name"],
                 user_profile["department"],
-            ],
+            ),
         ]
-    ):
-        return False
-    return True
+    )

--- a/imperial_coldfront_plugin/policy.py
+++ b/imperial_coldfront_plugin/policy.py
@@ -1,0 +1,33 @@
+"""Policy functionality governing the eligibility of users access RCS systems."""
+
+
+def _filter_entity_type(entity_type):
+    """Capture complex sublogic for filtering entity types."""
+    if entity_type is None:
+        return False
+    if "Room" in entity_type or entity_type == "Shared Mailbox":
+        return False
+    return True
+
+
+def user_eligible_for_hpc_access(user_profile):
+    """Assess the eligibility of a user to join a ResearchGroup.
+
+    Imperial identity systems contain entries for non-human entities such as rooms and
+    shared mailboxes that should be removed from consideration.
+    """
+    if any(
+        [
+            user_profile["user_type"] != "Member",
+            user_profile["record_status"] != "Live",
+            not _filter_entity_type(user_profile["entity_type"]),
+            None
+            in [
+                user_profile["email"],
+                user_profile["name"],
+                user_profile["department"],
+            ],
+        ]
+    ):
+        return False
+    return True

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -177,7 +177,7 @@ def parsed_profile():
         company_name="company",
         department="dept",
         job_family="job family",
-        employment_status="employment status",
+        entity_type="entity type",
         job_title=None,
         name="a name",
         email="email",
@@ -192,7 +192,7 @@ def profile(parsed_profile):
     return dict(
         onPremisesExtensionAttributes=dict(
             extensionAttribute14=parsed_profile["job_family"],
-            extensionAttribute6=parsed_profile["employment_status"],
+            extensionAttribute6=parsed_profile["entity_type"],
             extensionAttribute5=parsed_profile["record_status"],
         ),
         userType=parsed_profile["user_type"],

--- a/tests/test_microsoft_graph_client.py
+++ b/tests/test_microsoft_graph_client.py
@@ -10,41 +10,6 @@ from imperial_coldfront_plugin.microsoft_graph_client import (
 )
 
 
-@pytest.fixture
-def parsed_profile():
-    """Return a dictionary of profile data as structured by the graph client."""
-    return dict(
-        user_type="Member",
-        company_name="company",
-        department="dept",
-        job_family="job family",
-        employment_status="employment status",
-        job_title=None,
-        name="a name",
-        email="email",
-        username="username",
-        record_status="Live",
-    )
-
-
-@pytest.fixture
-def profile(parsed_profile):
-    """Return a dictionary of profile data as returned by the graph API."""
-    return dict(
-        onPremisesExtensionAttributes=dict(
-            extensionAttribute14=parsed_profile["job_family"],
-            extensionAttribute6=parsed_profile["employment_status"],
-            extensionAttribute5=parsed_profile["record_status"],
-        ),
-        userType=parsed_profile["user_type"],
-        companyName=parsed_profile["company_name"],
-        department=parsed_profile["department"],
-        displayName=parsed_profile["name"],
-        mail=parsed_profile["email"],
-        userPrincipalName=parsed_profile["username"] + "@ic.ac.uk",
-    )
-
-
 def test_parse_profile_data(profile, parsed_profile):
     """Test that the profile data is correctly parsed."""
     api_response = MagicMock()

--- a/tests/test_policy.py
+++ b/tests/test_policy.py
@@ -1,0 +1,24 @@
+import pytest
+
+from imperial_coldfront_plugin.policy import user_eligible_for_hpc_access
+
+
+def test_user_filter(parsed_profile):
+    """Test the user filter passes a valid profile."""
+    assert user_eligible_for_hpc_access(parsed_profile)
+
+
+@pytest.mark.parametrize(
+    "override_key, override_value",
+    [
+        ("user_type", ""),
+        ("record_status", ""),
+        ("email", None),
+        ("name", None),
+        ("department", None),
+    ],
+)
+def test_user_filter_invalid(override_key, override_value, parsed_profile):
+    """Test the user filter catches invalid profiles."""
+    parsed_profile[override_key] = override_value
+    assert not user_eligible_for_hpc_access(parsed_profile)


### PR DESCRIPTION
# Description

Fixes #103 

As described by the issue, current searches of the microsoft graph api return entities that should not be considered for HPC access e.g. rooms. This PR implements some basic filtering using the profile data returned from the API to catch obviously invalid entries.

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [X] All tests pass (eg. `python -m pytest`)
- [X] The documentation builds and looks OK (eg. `python -m sphinx -b html docs docs/build`)
- [X] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)

## Further checks

- [X] Code is commented, particularly in hard-to-understand areas
- [X] Tests added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
