### PR TITLE
Group expire

### DIFF
--- a/imperial_coldfront_plugin/management/__init__.py
+++ b/imperial_coldfront_plugin/management/__init__.py
@@ -1,0 +1,1 @@
+"""Django management module."""

--- a/imperial_coldfront_plugin/management/commands/__init__.py
+++ b/imperial_coldfront_plugin/management/commands/__init__.py
@@ -1,0 +1,1 @@
+"""Django management commands."""

--- a/imperial_coldfront_plugin/management/commands/prune_groups.py
+++ b/imperial_coldfront_plugin/management/commands/prune_groups.py
@@ -1,0 +1,29 @@
+"""Django management command to prune expired group memberships."""
+
+from argparse import ArgumentParser
+from typing import Any
+
+from django.core.management.base import BaseCommand
+from django.utils import timezone
+
+from imperial_coldfront_plugin.models import GroupMembership
+
+
+class Command(BaseCommand):
+    """Remove expired group memberships from the database."""
+
+    help = __doc__
+
+    def add_arguments(self, parser: ArgumentParser) -> None:
+        """Add commandline options."""
+        parser.add_argument("--debug", action="store_true")
+
+    def handle(self, debug: bool = False, **kwargs: Any) -> None:  # type: ignore[misc]
+        """Command business logic."""
+        query = GroupMembership.objects.filter(expiration__lt=timezone.now())
+
+        if debug:
+            self.stdout.write(f"Pruning {query.count()} expired group memberships.")
+
+        if query.count():
+            query.delete()

--- a/imperial_coldfront_plugin/models.py
+++ b/imperial_coldfront_plugin/models.py
@@ -48,14 +48,11 @@ class GroupMembership(models.Model):
         ResearchGroup,
         on_delete=models.CASCADE,
     )
-
     member = models.ForeignKey(
         settings.AUTH_USER_MODEL,
         on_delete=models.CASCADE,
     )
-
     is_manager = models.BooleanField(default=False)
-
     expiration = models.DateTimeField()
 
 

--- a/imperial_coldfront_plugin/models.py
+++ b/imperial_coldfront_plugin/models.py
@@ -41,6 +41,7 @@ class GroupMembership(models.Model):
         member (ForeignKey): A reference to the user designated as member, connected to
             AUTH_USER_MODEL. Deletes related memberships when the member is deleted.
         is_manager (BooleanField): A boolean value indicating if a member is a manager.
+        expiration (DateTimeField): The date and time when the membership expires.
     """
 
     group = models.ForeignKey(
@@ -54,6 +55,8 @@ class GroupMembership(models.Model):
     )
 
     is_manager = models.BooleanField(default=False)
+
+    expiration = models.DateTimeField()
 
 
 class UnixUID(models.Model):


### PR DESCRIPTION
# Description

Automatically prune old expired group memberships.
Fixes #80 
Fixes #81
Fixes #91 

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [x] All tests pass (eg. `python -m pytest`)
- [ ] The documentation builds and looks OK (eg. `python -m sphinx -b html docs docs/build`)
- [x] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
