### PR TITLE
Automatic PI identification

### DIFF
--- a/imperial_coldfront_plugin/policy.py
+++ b/imperial_coldfront_plugin/policy.py
@@ -29,3 +29,44 @@ def user_eligible_for_hpc_access(user_profile):
             ),
         ]
     )
+
+
+PI_DISALLOWED_DEPARTMENTS = [
+    "External Users",
+    "Reach Out",
+    "Catering Services",
+    "Careers Service",
+    "Early Years Education Centre",
+    "CONTRACTOR",
+    "NONE",
+    "Campus Services",
+    "Guest Access",
+    "Union",
+    "Registry",
+    "Residential Services",
+    "Estates Division",
+]
+PI_ALLOWED_TITLES = ["Fellow", "Lecturer", "Chair", "Professor", "Reader", "Director"]
+PI_DISALLOWED_TITLE_QUALIFIERS = ["Visiting", "Emeritus", "Honorary"]
+
+
+def user_eligible_to_be_pi(user_profile):
+    """Assess eligibilty of a user be a Principal Investigator."""
+    job_title = user_profile["job_title"]
+    if any(
+        (
+            user_profile["record_status"] != "Live",
+            user_profile["department"] in PI_DISALLOWED_DEPARTMENTS,
+            user_profile["employment_status"] not in ["Staff", "Employee"],
+            not job_title,
+        )
+    ):
+        return False
+
+    if not any(role in job_title for role in PI_ALLOWED_TITLES):
+        return False
+
+    if any(qualifier in job_title for qualifier in PI_DISALLOWED_TITLE_QUALIFIERS):
+        return False
+
+    return True

--- a/tests/test_policy.py
+++ b/tests/test_policy.py
@@ -1,6 +1,12 @@
 import pytest
 
-from imperial_coldfront_plugin.policy import user_eligible_for_hpc_access
+from imperial_coldfront_plugin.policy import (
+    PI_ALLOWED_TITLES,
+    PI_DISALLOWED_DEPARTMENTS,
+    PI_DISALLOWED_TITLE_QUALIFIERS,
+    user_eligible_for_hpc_access,
+    user_eligible_to_be_pi,
+)
 
 
 def test_user_filter(parsed_profile):
@@ -22,3 +28,35 @@ def test_user_filter_invalid(override_key, override_value, parsed_profile):
     """Test the user filter catches invalid profiles."""
     parsed_profile[override_key] = override_value
     assert not user_eligible_for_hpc_access(parsed_profile)
+
+
+@pytest.fixture
+def pi_user_profile():
+    """Valid user data for a PI."""
+    return {
+        "record_status": "Live",
+        "department": "Department of Computing",
+        "employment_status": "Staff",
+        "username": "test_user",
+        "job_title": "Professor of Computing",
+    }
+
+
+@pytest.mark.parametrize("job_title", PI_ALLOWED_TITLES)
+def test_user_eligible_to_be_pi(job_title, pi_user_profile):
+    """Test the user filter passes a valid profile."""
+    assert user_eligible_to_be_pi(pi_user_profile | dict(job_title=job_title))
+
+
+@pytest.mark.parametrize(
+    "override_key, override_value",
+    [
+        ("record_status", ""),
+        ("employment_status", "whatever"),
+    ]
+    + [("job_title", qualifier) for qualifier in PI_DISALLOWED_TITLE_QUALIFIERS]
+    + [("department", department) for department in PI_DISALLOWED_DEPARTMENTS],
+)
+def test_user_eligible_to_be_pi_invalid(override_key, override_value, pi_user_profile):
+    """Test the pi filter catches invalid profiles."""
+    assert not user_eligible_to_be_pi(pi_user_profile | {override_key: override_value})


### PR DESCRIPTION
# Description

A port of the PI identification logic from the old portal. At the moment this is a single function in the policy module (and tests) that will be used in later PRs.

Fixes #65 

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [X] All tests pass (eg. `python -m pytest`)
- [ ] The documentation builds and looks OK (eg. `python -m sphinx -b html docs docs/build`)
- [X] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)

## Further checks

- [X] Code is commented, particularly in hard-to-understand areas
- [X] Tests added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
