### PR TITLE
Implement get_group_data view

### DIFF
--- a/imperial_coldfront_plugin/urls.py
+++ b/imperial_coldfront_plugin/urls.py
@@ -29,6 +29,7 @@ urlpatterns = [
         name="remove_group_member",
     ),
     path("active_users/", views.get_active_users, name="get_active_users"),
+    path("groups/", views.get_group_data, name="get_group_data"),
     path("user_search/", views.user_search, name="user_search"),
     path(
         "make_manager/<int:group_membership_pk>/",

--- a/imperial_coldfront_plugin/views.py
+++ b/imperial_coldfront_plugin/views.py
@@ -290,6 +290,22 @@ def get_active_users(request: HttpRequest) -> HttpResponse:
     return HttpResponse(passwd)
 
 
+def get_group_data(request: HttpRequest) -> HttpResponse:
+    """Get the group data in unix etc/group format.
+
+    Args:
+        request: The HTTP request object containing metadata about the request.
+    """
+    groups = ""
+    format_str = "{group.name}:x:{group.gid}:{users}\n"
+    qs = ResearchGroup.objects.all()
+    for group in qs:
+        users = group.groupmembership_set.values_list("member__username", flat=True)
+        groups += format_str.format(group=group, users=",".join(users))
+
+    return HttpResponse(groups)
+
+
 @login_required
 def make_group_manager(request: HttpRequest, group_membership_pk: int) -> HttpResponse:
     """Make a group member a manager.

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -422,6 +422,27 @@ class TestGetActiveUsersView:
         assert b"" == response.content
 
 
+class TestGetGroupDataView:
+    """Tests for the get group data view."""
+
+    def _get_url(self):
+        return reverse("imperial_coldfront_plugin:get_group_data")
+
+    def test_user(self, client, research_group_factory):
+        """Test the get_group_data view returns the right data."""
+        group, memberships = research_group_factory(number_of_members=2)
+        user1 = memberships[0].member
+        user2 = memberships[1].member
+
+        response = client.get(self._get_url())
+        assert response.status_code == HTTPStatus.OK
+        expected = bytes(
+            f"{group.name}:x:{group.gid}:{user1},{user2}\n",
+            "utf-8",
+        )
+        assert response.content == expected
+
+
 class TestMakeGroupManagerView(LoginRequiredMixin):
     """Tests for the make group manager view."""
 


### PR DESCRIPTION
# Description

This adds a view to provide the /etc/groups endpoint for SoV

One thing I noticed when doing this is that there are no restriction on the ResearchGroup name. It needs to have the same restrictions as a unix group name (ie no spaces, possibly more). Should this be a new issue?

Fixes #36 

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [ ] All tests pass (eg. `python -m pytest`)
- [ ] The documentation builds and looks OK (eg. `python -m sphinx -b html docs docs/build`)
- [ ] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
