### PR TITLE
Add group membership extension view function

### DIFF
--- a/imperial_coldfront_plugin/forms.py
+++ b/imperial_coldfront_plugin/forms.py
@@ -23,3 +23,12 @@ class UserSearchForm(forms.Form):
     """Form for searching users."""
 
     search = forms.CharField(label="Search")
+
+
+class GroupMembershipExtendForm(forms.Form):
+    """Form for extending group membership."""
+
+    extend_length = forms.IntegerField(
+        label="Extend by (in days)",
+        min_value=1,
+    )

--- a/imperial_coldfront_plugin/templates/imperial_coldfront_plugin/extend_membership.html
+++ b/imperial_coldfront_plugin/templates/imperial_coldfront_plugin/extend_membership.html
@@ -1,7 +1,10 @@
 {% extends "common/base.html" %}
 {% block content %}
-  <p>Your current membership is due to expire on {{ expiry_date }}.</p>
-  Would you like to extend it?
+  <h1>Extend Membership</h1>
+  <p>User/member information:</p>
+  <p>Member name: {{ group_membership.member }}</p>
+  <p>Group name: {{ group_membership.group }}</p>
+  <p>Current expiry date: {{ group_membership.expiration }}</p>
   <form method="post">
     {% csrf_token %} {{ form.as_p }}
     <button type="submit">Extend Membership</button>

--- a/imperial_coldfront_plugin/templates/imperial_coldfront_plugin/extend_membership.html
+++ b/imperial_coldfront_plugin/templates/imperial_coldfront_plugin/extend_membership.html
@@ -1,0 +1,9 @@
+{% extends "common/base.html" %}
+{% block content %}
+  <p>Your current membership is due to expire on {{ expiry_date }}.</p>
+  Would you like to extend it?
+  <form method="post">
+    {% csrf_token %} {{ form.as_p }}
+    <button type="submit">Extend Membership</button>
+  </form>
+{% endblock content %}

--- a/imperial_coldfront_plugin/urls.py
+++ b/imperial_coldfront_plugin/urls.py
@@ -41,4 +41,9 @@ urlpatterns = [
         views.remove_group_manager,
         name="remove_manager",
     ),
+    path(
+        "extend_membership/<int:group_membership_pk>/",
+        views.group_membership_extend,
+        name="extend_membership",
+    ),
 ]

--- a/imperial_coldfront_plugin/views.py
+++ b/imperial_coldfront_plugin/views.py
@@ -422,10 +422,5 @@ def group_membership_extend(
         form = GroupMembershipExtendForm()
 
     return render(
-        request,
-        "imperial_coldfront_plugin/extend_membership.html",
-        {
-            "form": form,
-            "group_membership": group_membership,
-        },
+        request, "imperial_coldfront_plugin/extend_membership.html", dict(form=form)
     )

--- a/imperial_coldfront_plugin/views.py
+++ b/imperial_coldfront_plugin/views.py
@@ -366,3 +366,16 @@ def remove_group_manager(
     return redirect(
         reverse("imperial_coldfront_plugin:group_members", args=[group.owner.pk])
     )
+
+@login_required
+def group_membership_extend(
+    request: HttpRequest, group_membership_pk: int
+    ) -> HttpResponse:
+    """Extend the membership of a group member.
+
+    Args:
+        request: The HTTP request object containing metadata about the request.
+        group_membership_pk: The primary key of the group membership to be updated.
+    """
+    group_membership = get_object_or_404(GroupMembership, pk=group_membership_pk)
+    group = group_membership.group

--- a/imperial_coldfront_plugin/views.py
+++ b/imperial_coldfront_plugin/views.py
@@ -392,3 +392,35 @@ def group_membership_extend(
         ).exists()
     ):
         return HttpResponseForbidden("Permission denied")
+
+    # on GET request - display the user's information and the current expiry
+    # date as well as a form allowing them to specify the length of an
+    # extension.
+
+    if request.method == "GET":
+        return render(
+            request,
+            "imperial_coldfront_plugin/extend_membership.html",
+            {
+                "group_membership": group_membership,
+                "group": group,
+            },
+        )
+
+    # on POST request - updates the expiry date of the GroupMembership based on the
+    # form data and redirects to group_members_view.
+
+    if request.method == "POST":
+        form = GroupMembershipForm(request.POST)
+        if form.is_valid():
+            expiration = form.cleaned_data["expiration"]
+            group_membership.expiration = expiration
+            group_membership.save()
+            return redirect(
+                reverse(
+                    "imperial_coldfront_plugin:group_members", args=[group.owner.pk]
+                )
+            )
+        else:
+            return HttpResponseBadRequest("Invalid data")
+    return HttpResponseBadRequest("Invalid data")

--- a/imperial_coldfront_plugin/views.py
+++ b/imperial_coldfront_plugin/views.py
@@ -425,5 +425,7 @@ def group_membership_extend(
         form = GroupMembershipExtendForm()
 
     return render(
-        request, "imperial_coldfront_plugin/extend_membership.html", dict(form=form)
+        request,
+        "imperial_coldfront_plugin/extend_membership.html",
+        dict(form=form, group_membership=group_membership),
     )

--- a/imperial_coldfront_plugin/views.py
+++ b/imperial_coldfront_plugin/views.py
@@ -383,8 +383,7 @@ def group_membership_extend(
 
     Args:
         request: The HTTP request object containing metadata about the request.
-        group_membership_pk: The primary key of the group membership to be
-        updated.
+        group_membership_pk: The primary key of the group membership to be updated.
     """
     group_membership = get_object_or_404(GroupMembership, pk=group_membership_pk)
     group = group_membership.group

--- a/imperial_coldfront_plugin/views.py
+++ b/imperial_coldfront_plugin/views.py
@@ -400,6 +400,9 @@ def group_membership_extend(
     ):
         return HttpResponseForbidden("Permission denied")
 
+    if group_membership.member == request.user:
+        return HttpResponseForbidden("You cannot extend your own membership.")
+
     # on GET request - display the user's information and the current expiry
     # date as well as a form allowing them to specify the length of an
     # extension.

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -585,10 +585,15 @@ class TestGroupMembershipExtendView(LoginRequiredMixin):
     def test_not_group_owner(
         self, research_group_factory, auth_client_factory, user_client, pi_group
     ):
-        """Test non group owner or manager cannot access the view."""
+        """Test non group owner or non group manager cannot access the view."""
         group, memberships = research_group_factory(number_of_members=1)
         client = auth_client_factory(group.owner)
         response = client.get(self._get_url())
+        assert response.status_code == HTTPStatus.FORBIDDEN
+        assert response.content == b"Permission denied"
+
+        group_membership = pi_group.groupmembership_set.first()
+        response = user_client.get(self._get_url(group_membership.pk))
         assert response.status_code == HTTPStatus.FORBIDDEN
         assert response.content == b"Permission denied"
 

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -599,6 +599,17 @@ class TestGroupMembershipExtendView(LoginRequiredMixin):
         assert response.status_code == HTTPStatus.OK
         assert isinstance(response.context["form"], GroupMembershipExtendForm)
 
+    def test_manager_cannot_extend_own_membership(
+        self, manager_in_group, auth_client_factory
+    ):
+        """Test that a group manager cannot extend their own membership."""
+        manager, group = manager_in_group
+        group_membership = group.groupmembership_set.get(member=manager)
+        client = auth_client_factory(manager)
+        response = client.get(self._get_url(group_membership.pk))
+        assert response.status_code == HTTPStatus.FORBIDDEN
+        assert response.content == b"You cannot extend your own membership."
+
     def test_successful_membership_extension(self, pi_client, pi_group):
         """Test successful extension of group membership."""
         group_membership = pi_group.groupmembership_set.first()

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -589,20 +589,3 @@ class TestGroupMembershipExtendView(LoginRequiredMixin):
         response = client.get(self._get_url())
         assert response.status_code == HTTPStatus.FORBIDDEN
         assert response.content == b"Permission denied"
-
-    def test_group_owner(self, pi_client, pi_group):
-        """Test that the group owner can extend a group membership."""
-        group_membership = pi_group.groupmembership_set.first()
-        response = pi_client.get(self._get_url(group_membership.pk))
-        assertRedirects(
-            response,
-            reverse(
-                "imperial_coldfront_plugin:group_members",
-                args=[group_membership.group.owner.pk],
-            ),
-        )
-
-    def test_invalid_groupmembership(self, user_client):
-        """Test the view response for an invalid group membership."""
-        response = user_client.get(self._get_url(1))
-        assert response.status_code == HTTPStatus.NOT_FOUND

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -598,6 +598,7 @@ class TestGroupMembershipExtendView(LoginRequiredMixin):
         response = pi_client.get(self._get_url(group_membership.pk))
         assert response.status_code == HTTPStatus.OK
         assert isinstance(response.context["form"], GroupMembershipExtendForm)
+        assert response.context["group_membership"] == group_membership
 
     def test_manager_cannot_extend_own_membership(
         self, manager_in_group, auth_client_factory

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -10,6 +10,7 @@ from django.shortcuts import reverse
 from pytest_django.asserts import assertRedirects, assertTemplateUsed
 
 from imperial_coldfront_plugin.forms import (
+    GroupMembershipExtendForm,
     TermsAndConditionsForm,
     UserSearchForm,
 )
@@ -589,3 +590,10 @@ class TestGroupMembershipExtendView(LoginRequiredMixin):
         response = client.get(self._get_url())
         assert response.status_code == HTTPStatus.FORBIDDEN
         assert response.content == b"Permission denied"
+
+    def test_group_owner(self, pi_client, pi_group):
+        """Test that the group owner can extend a group membership."""
+        group_membership = pi_group.groupmembership_set.first()
+        response = pi_client.get(self._get_url(group_membership.pk))
+        assert response.status_code == HTTPStatus.OK
+        assert isinstance(response.context["form"], GroupMembershipExtendForm)


### PR DESCRIPTION
# Description

This PR adds a new group membership extension view function using the group membership pk as an argument.

To do:
- [x] check that the accessing user is an owner/manager of the group in question (or a superadmin).
- [x] on GET request - display the user's information and the current expiry date as well as a form allowing them to specify the length of an extension.
- [x] on POST request - updates the expiry date of the GroupMembership based on the form data and redirects to `group_members_view`.
- [x] add unit test

Fixes #86 

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [x] All tests pass (eg. `python -m pytest`)
- [ ] The documentation builds and looks OK (eg. `python -m sphinx -b html docs docs/build`)
- [x] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
