### PR TITLE
Grp expire send accept

### DIFF
--- a/imperial_coldfront_plugin/forms.py
+++ b/imperial_coldfront_plugin/forms.py
@@ -7,6 +7,7 @@ class GroupMembershipForm(forms.Form):
     """Form for inviting a user to a research group."""
 
     username = forms.CharField()
+    expiration = forms.DateTimeField()
 
 
 class TermsAndConditionsForm(forms.Form):

--- a/imperial_coldfront_plugin/views.py
+++ b/imperial_coldfront_plugin/views.py
@@ -209,16 +209,13 @@ def accept_group_invite(request: HttpRequest, token: str) -> HttpResponse:
         )
 
     group = ResearchGroup.objects.get(owner__pk=invite["inviter_pk"])
-
-    from django.utils import timezone
+    expiration = timezone.datetime.fromisoformat(invite["expiration"])
 
     if request.method == "POST":
         form = TermsAndConditionsForm(request.POST)
         # Check if the user has accepted the terms and conditions.
         if form.is_valid():
             # Update group membership in the database.
-            # TODO: Temp hack: Get expiration from UI.
-            expiration = timezone.datetime.max
             GroupMembership.objects.get_or_create(
                 group=group, member=request.user, expiration=expiration
             )


### PR DESCRIPTION
# Description

Adds a group membership expiration field to the invite form, and use it in the send and accept invite views.

NB: neither datetimes nor timedeltas may be serialised by the token fn, so I instead used an ISO format datetime string. Not really sure how to feed in py datetimes from `user_search.html` though, so haven't done that.

Test added to check that membership expiry is not in past.

Fixes #90 

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [x] All tests pass (eg. `python -m pytest`)
- [ ] The documentation builds and looks OK (eg. `python -m sphinx -b html docs docs/build`)
- [x] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [x] Tests added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
