### PR TITLE
Override coldfront home page

### DIFF
--- a/imperial_coldfront_plugin/policy.py
+++ b/imperial_coldfront_plugin/policy.py
@@ -57,7 +57,7 @@ def user_eligible_to_be_pi(user_profile):
         (
             user_profile["record_status"] != "Live",
             user_profile["department"] in PI_DISALLOWED_DEPARTMENTS,
-            user_profile["employment_status"] not in ["Staff", "Employee"],
+            user_profile["entity_type"] not in ["Staff", "Employee"],
             not job_title,
         )
     ):

--- a/imperial_coldfront_plugin/templates/imperial_coldfront_plugin/eligible_pi.html
+++ b/imperial_coldfront_plugin/templates/imperial_coldfront_plugin/eligible_pi.html
@@ -1,0 +1,5 @@
+<p class="lead">
+  You have been identified as eligible to create a HPC Access Group. This will provide
+  you access to the HPC resources provided by the RCS and allow you to grant access to
+  other users.
+</p>

--- a/imperial_coldfront_plugin/templates/imperial_coldfront_plugin/home.html
+++ b/imperial_coldfront_plugin/templates/imperial_coldfront_plugin/home.html
@@ -1,0 +1,14 @@
+{% load home_tags %}
+<h1 class="display-4">Welcome to Coldfront</h1>
+<p>
+  This system is used to manage the resources provided by the Research Computing
+  Service including High Performance Computing (HPC) and the Research Data Facility.
+</p>
+{% owns_a_group request.user as does_own %}
+{% if not does_own %}
+  {% is_eligible_to_own_a_group request.user as can_own %}
+  {% is_a_group_member request.user as is_member %}
+  {% if can_own and not is_member %}
+    {% include "imperial_coldfront_plugin/eligible_pi.html" %}
+  {% endif %}
+{% endif %}

--- a/imperial_coldfront_plugin/templatetags/__init__.py
+++ b/imperial_coldfront_plugin/templatetags/__init__.py
@@ -1,0 +1,1 @@
+"""Template tags."""

--- a/imperial_coldfront_plugin/templatetags/home_tags.py
+++ b/imperial_coldfront_plugin/templatetags/home_tags.py
@@ -1,0 +1,29 @@
+"""Template tags for the home view."""
+
+from django import template
+
+from ..microsoft_graph_client import get_graph_api_client
+from ..models import GroupMembership, ResearchGroup
+from ..policy import user_eligible_to_be_pi
+
+register = template.Library()
+
+
+@register.simple_tag
+def owns_a_group(user):
+    """Check if the user owns a ResearchGroup."""
+    return ResearchGroup.objects.filter(owner=user).exists()
+
+
+@register.simple_tag
+def is_a_group_member(user):
+    """Check if the user is a member of a ResearchGroup."""
+    return GroupMembership.objects.filter(member=user).exists()
+
+
+@register.simple_tag
+def is_eligible_to_own_a_group(user):
+    """Check if the user is eligible to own a group."""
+    client = get_graph_api_client()
+    user_profile = client.user_profile(user.username)
+    return user_eligible_to_be_pi(user_profile)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -214,3 +214,15 @@ def profile(parsed_profile):
         mail=parsed_profile["email"],
         userPrincipalName=parsed_profile["username"] + "@ic.ac.uk",
     )
+
+
+@pytest.fixture
+def pi_user_profile():
+    """Valid user data for a PI."""
+    return {
+        "record_status": "Live",
+        "department": "Department of Computing",
+        "entity_type": "Staff",
+        "username": "test_user",
+        "job_title": "Professor of Computing",
+    }

--- a/tests/test_policy.py
+++ b/tests/test_policy.py
@@ -30,18 +30,6 @@ def test_user_filter_invalid(override_key, override_value, parsed_profile):
     assert not user_eligible_for_hpc_access(parsed_profile)
 
 
-@pytest.fixture
-def pi_user_profile():
-    """Valid user data for a PI."""
-    return {
-        "record_status": "Live",
-        "department": "Department of Computing",
-        "employment_status": "Staff",
-        "username": "test_user",
-        "job_title": "Professor of Computing",
-    }
-
-
 @pytest.mark.parametrize("job_title", PI_ALLOWED_TITLES)
 def test_user_eligible_to_be_pi(job_title, pi_user_profile):
     """Test the user filter passes a valid profile."""
@@ -52,7 +40,7 @@ def test_user_eligible_to_be_pi(job_title, pi_user_profile):
     "override_key, override_value",
     [
         ("record_status", ""),
-        ("employment_status", "whatever"),
+        ("entity_type", "whatever"),
     ]
     + [("job_title", qualifier) for qualifier in PI_DISALLOWED_TITLE_QUALIFIERS]
     + [("department", department) for department in PI_DISALLOWED_DEPARTMENTS],

--- a/tests/test_templatetags.py
+++ b/tests/test_templatetags.py
@@ -1,0 +1,51 @@
+"""Tests for template tags."""
+
+import pytest
+
+from imperial_coldfront_plugin.templatetags.home_tags import (
+    is_a_group_member,
+    is_eligible_to_own_a_group,
+    owns_a_group,
+)
+
+
+@pytest.fixture
+def get_graph_api_client_mock(mocker, parsed_profile):
+    """Mock out get_graph_api_client for home_tags.py."""
+    mock = mocker.patch(
+        "imperial_coldfront_plugin.templatetags.home_tags.get_graph_api_client"
+    )
+    mock().user_profile.return_value = parsed_profile
+    return mock
+
+
+class TestHomeTags:
+    """Tests for the home_tags template tags."""
+
+    def test_owns_a_group_true(self, pi, pi_group):
+        """Test true condition of owns_a_group tag."""
+        assert owns_a_group(pi)
+
+    def test_owns_a_group_false(self, user):
+        """Test false condition of owns_a_group tag."""
+        assert not owns_a_group(user)
+
+    def test_is_a_group_member_true(self, pi_group):
+        """Test true condition of is_a_group_member tag."""
+        user = pi_group.groupmembership_set.first().member
+        assert is_a_group_member(user)
+
+    def test_is_a_group_member_false(self, user):
+        """Test false condition of is_a_group_member tag."""
+        assert not is_a_group_member(user)
+
+    def test_is_eligible_to_own_a_group_true(
+        self, get_graph_api_client_mock, pi_user_profile, user
+    ):
+        """Test true condition of is_eligible_to_own_a_group tag."""
+        get_graph_api_client_mock().user_profile.return_value = pi_user_profile
+        assert is_eligible_to_own_a_group(user)
+
+    def test_is_eligible_to_own_a_group_false(self, get_graph_api_client_mock, user):
+        """Test false condition of is_eligible_to_own_a_group tag."""
+        assert not is_eligible_to_own_a_group(user)


### PR DESCRIPTION
# Description

Overrides the template for the base Coldfront home view to customise it with our content. I was hoping this could be carried out only in the plugin but have had to also implement an override in the development override so please make sure you have the `home-override` branch checked out in the development environment when testing this.

As we are only updating a template and not the view function we're not able to control the context that is passed to the template. To work around this we use template tags which effectively allow calling custom python code during template rending.

The tests also have to check the template rendering directly rather than calling the view function as it is tricky to call one of the coldfront views in the plugin tests.

Does not yet include a link to create the group as this is waiting on #67.

Also fixes a bug spotted in `policy.user_eligible_to_be_pi`.

Fixes #68 

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [X] All tests pass (eg. `python -m pytest`)
- [ ] The documentation builds and looks OK (eg. `python -m sphinx -b html docs docs/build`)
- [X] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)

## Further checks

- [X] Code is commented, particularly in hard-to-understand areas
- [X] Tests added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
