### PR TITLE
UI changes for group membership expiration

### DIFF
--- a/imperial_coldfront_plugin/forms.py
+++ b/imperial_coldfront_plugin/forms.py
@@ -7,7 +7,7 @@ class GroupMembershipForm(forms.Form):
     """Form for inviting a user to a research group."""
 
     username = forms.CharField()
-    expiration = forms.DateTimeField()
+    expiration = forms.DateField()
 
 
 class TermsAndConditionsForm(forms.Form):

--- a/imperial_coldfront_plugin/templates/group_members.html
+++ b/imperial_coldfront_plugin/templates/group_members.html
@@ -4,7 +4,7 @@
   <ul>
     {% for member in group_members %}
       <li>
-        {{ member.member.get_full_name }} -
+        {{ member.member.get_full_name }} (expires {{ member.expiration }}) -
         <a href="{% url 'imperial_coldfront_plugin:remove_group_member' member.pk %}">Remove access</a>
         {% if is_manager == False and member.is_manager == False %}
           | <a href="{% url 'imperial_coldfront_plugin:make_manager' member.pk %}">Make manager</a>
@@ -12,7 +12,6 @@
         {% if member.is_manager and is_manager == False %}
           | <a href="{% url 'imperial_coldfront_plugin:remove_manager' member.pk %}">Remove manager</a>
         {% endif %}
-        Membership expires on {{ member.expiration }}
       </li>
     {% endfor %}
   </ul>

--- a/imperial_coldfront_plugin/templates/group_members.html
+++ b/imperial_coldfront_plugin/templates/group_members.html
@@ -12,6 +12,7 @@
         {% if member.is_manager and is_manager == False %}
           | <a href="{% url 'imperial_coldfront_plugin:remove_manager' member.pk %}">Remove manager</a>
         {% endif %}
+        Membership expires on {{ member.expiration }}
       </li>
     {% endfor %}
   </ul>

--- a/imperial_coldfront_plugin/templates/imperial_coldfront_plugin/user_search.html
+++ b/imperial_coldfront_plugin/templates/imperial_coldfront_plugin/user_search.html
@@ -5,7 +5,8 @@
     <input type="submit" value="Search" />
   </form>
   {% if search_results %}
-    <form action="{% url 'imperial_coldfront_plugin:send_group_invite' %}" method="post"">
+    <form action="{% url 'imperial_coldfront_plugin:send_group_invite' %}"
+          method="post">
       {% csrf_token %}
       <table>
         <tr>
@@ -27,7 +28,24 @@
           </tr>
         {% endfor %}
       </table>
+      <label for="expiration">Expiration date (within 5 years):</label>
+      <input type="date" id="expiration" name="expiration">
       <input type="submit" value="Invite" />
     </form>
   {% endif %}
+  <script>
+    const dateInput = document.getElementById('expiration');
+
+    // Get formatted date for today and the future limit.
+    const date = new Date();
+    const formattedToday = date.toISOString().split('T')[0];
+    date.setFullYear(date.getFullYear() + 5);
+    const formattedLimit = date.toISOString().split('T')[0];
+
+    // Set min and max attribute to restrict date selection.
+    dateInput.setAttribute('min', formattedToday);
+    dateInput.setAttribute('max', formattedLimit);
+    console.log('Min Date Set:', dateInput.min);
+    console.log('Max Date Set:', dateInput.max);
+  </script>
 {% endblock content %}

--- a/imperial_coldfront_plugin/templates/imperial_coldfront_plugin/user_search.html
+++ b/imperial_coldfront_plugin/templates/imperial_coldfront_plugin/user_search.html
@@ -45,7 +45,5 @@
     // Set min and max attribute to restrict date selection.
     dateInput.setAttribute('min', formattedToday);
     dateInput.setAttribute('max', formattedLimit);
-    console.log('Min Date Set:', dateInput.min);
-    console.log('Max Date Set:', dateInput.max);
   </script>
 {% endblock content %}

--- a/imperial_coldfront_plugin/views.py
+++ b/imperial_coldfront_plugin/views.py
@@ -151,7 +151,7 @@ def send_group_invite(request: HttpRequest) -> HttpResponse:
         if form.is_valid():
             expiration = form.cleaned_data["expiration"]
 
-            if expiration < timezone.now():
+            if expiration < timezone.now().date():
                 return HttpResponseBadRequest("Expiration date should be in the future")
 
             username = form.cleaned_data["username"]

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -150,7 +150,7 @@ class TestSendGroupInviteView(LoginRequiredMixin):
         """Test that a group manager can access the view."""
         manager, group = manager_in_group
         client = auth_client_factory(manager)
-        data = {"username": "username", "expiration": timezone.datetime.max}
+        data = {"username": "username", "expiration": timezone.datetime.max.date()}
         response = client.post(self._get_url(), data=data)
         assert response.status_code == 200
 
@@ -166,7 +166,7 @@ class TestSendGroupInviteView(LoginRequiredMixin):
     ):
         """Test that the view sends an email when a POST request is made."""
         invitee_email = parsed_profile["email"]
-        data = {"username": "username", "expiration": timezone.datetime.max}
+        data = {"username": "username", "expiration": timezone.datetime.max.date()}
         response = pi_client.post(self._get_url(), data=data)
         assert response.status_code == HTTPStatus.OK
         assert f"Invitation sent to {invitee_email}" in response.content.decode()
@@ -189,7 +189,7 @@ class TestSendGroupInviteView(LoginRequiredMixin):
             "imperial_coldfront_plugin.views.user_eligible_for_hpc_access"
         )
         user_filter_mock.return_value = False
-        data = {"username": "username", "expiration": timezone.datetime.max}
+        data = {"username": "username", "expiration": timezone.datetime.max.date()}
         response = pi_client.post(self._get_url(), data=data)
         assert response.status_code == HTTPStatus.BAD_REQUEST
         assert response.content == b"User not found or not eligible"
@@ -198,7 +198,7 @@ class TestSendGroupInviteView(LoginRequiredMixin):
         self, get_graph_api_client_mock, pi, pi_group, pi_client
     ):
         """Check that a group expiration in the past is rejected."""
-        data = {"username": "username", "expiration": timezone.datetime.min}
+        data = {"username": "username", "expiration": timezone.datetime.min.date()}
         response = pi_client.post(self._get_url(), data=data)
         assert response.status_code == HTTPStatus.BAD_REQUEST
         assert response.content == b"Expiration date should be in the future"


### PR DESCRIPTION
# Description

Read a chosen membership expiration from the user_search.html invite form. Also display expiration in the group view.

Change the form to use a date, not a datetime -- seems silly to chose the minute of expiration.

Some light JS was necessary to enforce minimum today's date, and maximum some way into the future: currently 5 years. Can maybe be a setting passed into the template?

Fix a double quite typo: `<form action="{% url 'imperial_coldfront_plugin:send_group_invite' %}" method="post"">`.

Fixes #84 

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [x] All tests pass (eg. `python -m pytest`)
- [ ] The documentation builds and looks OK (eg. `python -m sphinx -b html docs docs/build`)
- [x] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
