### PR TITLE
Group membership extension UI + expiry info add

### DIFF
--- a/imperial_coldfront_plugin/emails.py
+++ b/imperial_coldfront_plugin/emails.py
@@ -23,14 +23,15 @@ def send_email_in_background(to_addresses: list[str], subject: str, body: str):
     )
 
 
-def send_group_invite_email(invitee_email, owner, invite_url):
+def send_group_invite_email(invitee_email, owner, invite_url, expiration):
     """Notify a user that they have been invited to join a ResearchGroup."""
     send_email_in_background(
         [invitee_email],
         "HPC Access Invitation",
         "You've been invited to join the access group of "
         f"{owner.get_full_name()} ({owner.email})\n\n"
-        f"Click the following link to accept the invitation:\n{invite_url}",
+        f"Click the following link to accept the invitation:\n{invite_url}.\n"
+        f"Your membership is due to expire on {expiration}.",
     )
 
 
@@ -40,7 +41,7 @@ def send_group_access_granted_email(user, owner):
         [user.email, owner.email],
         "HPC Access Granted",
         f"This email is to confirm that {user.get_full_name()} ({user.email}) has been"
-        f"granted access to the HPC access group of {owner.get_full_name()}.",
+        f"granted access to the HPC access group of {owner.get_full_name()}",
     )
 
 

--- a/imperial_coldfront_plugin/templates/group_members.html
+++ b/imperial_coldfront_plugin/templates/group_members.html
@@ -15,4 +15,21 @@
       </li>
     {% endfor %}
   </ul>
+  <h1>Membership Extension</h1>
+  <table>
+    <tr>
+      <th>Name</th>
+      <th>Expiration Date</th>
+      <th>Actions</th>
+    </tr>
+    {% for member in group_members %}
+      <tr>
+        <td>{{ member.member.get_full_name }}</td>
+        <td>{{ member.expiration }}</td>
+        <td>
+          <a href="{% url 'imperial_coldfront_plugin:extend_membership' member.pk %}">Extend Membership</a>
+        </td>
+      </tr>
+    {% endfor %}
+  </table>
 {% endblock content %}

--- a/imperial_coldfront_plugin/templates/imperial_coldfront_plugin/accept_group_invite.html
+++ b/imperial_coldfront_plugin/templates/imperial_coldfront_plugin/accept_group_invite.html
@@ -3,6 +3,6 @@
   <h1>Invitation accepted</h1>
   <p>
     You have accepted a group invitation from user <em>{{ inviter }}</em>,
-    and are now a member of group <em>{{ group }}</em>.
+    and are now a member of group <em>{{ group }}</em>. Your membership will expire on <em>{{ expiration }}</em>.
   </p>
 {% endblock content %}

--- a/imperial_coldfront_plugin/views.py
+++ b/imperial_coldfront_plugin/views.py
@@ -223,13 +223,22 @@ def accept_group_invite(request: HttpRequest, token: str) -> HttpResponse:
             return render(
                 request=request,
                 template_name="imperial_coldfront_plugin/accept_group_invite.html",
-                context={"inviter": group.owner, "group": group.name},
+                context={
+                    "inviter": group.owner,
+                    "group": group.name,
+                    "expiration": expiration,
+                },
             )
     else:
         form = TermsAndConditionsForm()
     return render(
         request=request,
-        context={"inviter": group.owner, "group": group.name, "form": form},
+        context={
+            "inviter": group.owner,
+            "group": group.name,
+            "expiration": expiration,
+            "form": form,
+        },
         template_name="imperial_coldfront_plugin/member_terms_and_conditions.html",
     )
 

--- a/imperial_coldfront_plugin/views.py
+++ b/imperial_coldfront_plugin/views.py
@@ -175,7 +175,7 @@ def send_group_invite(request: HttpRequest) -> HttpResponse:
             invite_url = request.build_absolute_uri(
                 reverse("imperial_coldfront_plugin:accept_group_invite", args=[token])
             )
-            send_group_invite_email(invitee_email, request.user, invite_url)
+            send_group_invite_email(invitee_email, request.user, invite_url, expiration)
             return render(
                 request,
                 "imperial_coldfront_plugin/invite_sent.html",

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -602,6 +602,7 @@ class TestRemoveGroupManagerView(LoginRequiredMixin):
         assert member.email in email.body
         assert member.get_full_name() in email.body
 
+
 class TestGroupMembershipExtendView(LoginRequiredMixin):
     """Tests for the group membership extend view."""
 


### PR DESCRIPTION
# Description

This pull request addresses the following:
- Adds a membership extension section to the group members page
- Updates the group invitation acceptance message to include expiration details, and modifies the corresponding view to pass the expiration context.

Fixes #87, #123

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [x] All tests pass (eg. `python -m pytest`)
- [ ] The documentation builds and looks OK (eg. `python -m sphinx -b html docs docs/build`)
- [x] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
