### PR TITLE
Fix "manage your group" menu item

### DIFF
--- a/imperial_coldfront_plugin/templates/imperial_coldfront_plugin/group_menu.html
+++ b/imperial_coldfront_plugin/templates/imperial_coldfront_plugin/group_menu.html
@@ -1,11 +1,10 @@
+{% load navbar_tags %}
 <li id="navbar-project-menu" class="nav-item dropdown">
   <a class="nav-link dropdown-toggle" href="#" data-toggle="dropdown">HPC Access Management</a>
   <div class="dropdown-menu">
     <a class="dropdown-item"
        href="{% url 'imperial_coldfront_plugin:check_access' %}">Check Access</a>
-    {% if request.user.userprofile.is_pi %}
-      <a class="dropdown-item"
-         href="{% url 'imperial_coldfront_plugin:group_members' request.user.pk %}">Manage Your Group</a>
-    {% endif %}
+    {% get_group_url request.user as group_url %}
+    {% if group_url %}<a class="dropdown-item" href="{{ group_url }}">Manage Your Group</a>{% endif %}
   </div>
 </li>

--- a/imperial_coldfront_plugin/templatetags/navbar_tags.py
+++ b/imperial_coldfront_plugin/templatetags/navbar_tags.py
@@ -1,0 +1,21 @@
+"""Template tags for the navbar."""
+
+from django import template
+from django.urls import reverse
+
+from ..models import GroupMembership, ResearchGroup
+
+register = template.Library()
+
+
+@register.simple_tag
+def get_group_url(user):
+    """Get the URL for a group owned or managed by user."""
+    try:
+        group = ResearchGroup.objects.get(owner=user)
+    except ResearchGroup.DoesNotExist:
+        try:
+            group = GroupMembership.objects.get(member=user, is_manager=True).group
+        except GroupMembership.DoesNotExist:
+            return None
+    return reverse("imperial_coldfront_plugin:group_members", args=[group.pk])

--- a/tests/test_templatetags.py
+++ b/tests/test_templatetags.py
@@ -1,12 +1,14 @@
 """Tests for template tags."""
 
 import pytest
+from django.urls import reverse
 
 from imperial_coldfront_plugin.templatetags.home_tags import (
     is_a_group_member,
     is_eligible_to_own_a_group,
     owns_a_group,
 )
+from imperial_coldfront_plugin.templatetags.navbar_tags import get_group_url
 
 
 @pytest.fixture
@@ -49,3 +51,24 @@ class TestHomeTags:
     def test_is_eligible_to_own_a_group_false(self, get_graph_api_client_mock, user):
         """Test false condition of is_eligible_to_own_a_group tag."""
         assert not is_eligible_to_own_a_group(user)
+
+
+class TestNavbarTags:
+    """Tests for the navbar_tags template tags."""
+
+    def test_get_group_url_none(self, user):
+        """Test get_group_url returns None for a user with no group."""
+        assert get_group_url(user) is None
+
+    def test_get_group_url_owner(self, pi, pi_group):
+        """Test get_group_url returns the correct URL for a group owner."""
+        assert get_group_url(pi) == reverse(
+            "imperial_coldfront_plugin:group_members", args=[pi_group.pk]
+        )
+
+    def test_get_group_url_manager(self, manager_in_group):
+        """Test get_group_url returns the correct URL for a group manager."""
+        manager, group = manager_in_group
+        assert get_group_url(manager) == reverse(
+            "imperial_coldfront_plugin:group_members", args=[group.pk]
+        )


### PR DESCRIPTION
# Description

This was broken by #118. Adds a template tag that checks if a user is the owner or manager of a group and if so returns the url to view it. This tag is used by the template to populate the "Manage your group" item in the navbar.

Fixes #117

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [X] All tests pass (eg. `python -m pytest`)
- [X] The documentation builds and looks OK (eg. `python -m sphinx -b html docs docs/build`)
- [X] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)

## Further checks

- [X] Code is commented, particularly in hard-to-understand areas
- [X] Tests added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
