### PR TITLE
Testing Refactor

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -157,6 +157,33 @@ def pi_group(research_group_factory, pi):
 
 
 @pytest.fixture
+def pi_group_member(pi_group):
+    """Provides the member of pi_group."""
+    return pi_group.groupmembership_set.first().member
+
+
+@pytest.fixture
+def pi_group_membership(pi_group_member):
+    """Provides the GroupMembership object for pi_group_member."""
+    return pi_group_member.groupmembership
+
+
+@pytest.fixture
+def pi_group_manager(pi_group, user_factory):
+    """Provides a manager for pi_group."""
+    from imperial_coldfront_plugin.models import GroupMembership
+
+    manager = user_factory(username="manager")
+    GroupMembership.objects.create(
+        group=pi_group,
+        member=manager,
+        is_manager=True,
+        expiration=timezone.datetime.max,
+    )
+    return manager
+
+
+@pytest.fixture
 def user_client(auth_client_factory, user):
     """Return an authenticated Django test client for `user`."""
     return auth_client_factory(user)
@@ -166,19 +193,6 @@ def user_client(auth_client_factory, user):
 def pi_client(auth_client_factory, pi):
     """Return an authenticated Django test client for a PI."""
     return auth_client_factory(pi)
-
-
-@pytest.fixture
-def manager_in_group(user_factory, research_group_factory):
-    """Return a user who is a manager in a research group."""
-    from imperial_coldfront_plugin.models import GroupMembership
-
-    manager = user_factory()
-    group, memberships = research_group_factory(number_of_members=3)
-    GroupMembership.objects.create(
-        group=group, member=manager, is_manager=True, expiration=timezone.now()
-    )
-    return manager, group
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -240,3 +240,44 @@ def pi_user_profile():
         "username": "test_user",
         "job_title": "Professor of Computing",
     }
+
+
+@pytest.fixture
+def superuser(user_factory):
+    """Return a superuser."""
+    return user_factory(is_superuser=True)
+
+
+def _get_user_fixture(request):
+    """Return a user fixture."""
+    return request.getfixturevalue(request.param)
+
+
+@pytest.fixture(params=["pi", "pi_group_manager", "superuser"])
+def pi_manager_or_superuser(request):
+    """Parametrized fixture providing a pi, manager or superuser."""
+    return _get_user_fixture(request)
+
+
+@pytest.fixture(params=["pi", "superuser"])
+def pi_or_superuser(request):
+    """Parametrized fixture providing a pi or superuser."""
+    return _get_user_fixture(request)
+
+
+@pytest.fixture(params=["pi_group_member", "pi_group_manager"])
+def member_or_manager(request):
+    """Parametrized fixture providing a member or manager."""
+    return _get_user_fixture(request)
+
+
+@pytest.fixture(params=["user", "pi_group_member"])
+def user_or_member(request):
+    """Parametrized fixture providing a user or member."""
+    return _get_user_fixture(request)
+
+
+@pytest.fixture(params=["user", "pi_group_member", "pi_group_manager"])
+def user_member_or_manager(request):
+    """Parametrized fixture providing a user, member or manager."""
+    return _get_user_fixture(request)

--- a/tests/test_templatetags.py
+++ b/tests/test_templatetags.py
@@ -66,9 +66,8 @@ class TestNavbarTags:
             "imperial_coldfront_plugin:group_members", args=[pi_group.pk]
         )
 
-    def test_get_group_url_manager(self, manager_in_group):
+    def test_get_group_url_manager(self, pi_group, pi_group_manager):
         """Test get_group_url returns the correct URL for a group manager."""
-        manager, group = manager_in_group
-        assert get_group_url(manager) == reverse(
-            "imperial_coldfront_plugin:group_members", args=[group.pk]
+        assert get_group_url(pi_group_manager) == reverse(
+            "imperial_coldfront_plugin:group_members", args=[pi_group.pk]
         )

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -40,6 +40,15 @@ class LoginRequiredMixin:
         assert response.url.startswith(settings.LOGIN_URL)
 
 
+class GroupMembershipPKMixin:
+    """Mixin for tests that require a group membership pk."""
+
+    def test_invalid_groupmembership(self, user_client):
+        """Test the view response for an invalid group membership."""
+        response = user_client.get(self._get_url())
+        assert response.status_code == HTTPStatus.NOT_FOUND
+
+
 class TestGroupMembersView(LoginRequiredMixin):
     """Tests for the group members view."""
 
@@ -313,7 +322,7 @@ class TestCheckAccessView(LoginRequiredMixin):
         )
 
 
-class TestRemoveGroupMemberView(LoginRequiredMixin):
+class TestRemoveGroupMemberView(LoginRequiredMixin, GroupMembershipPKMixin):
     """Tests for the remove group member view."""
 
     def _get_url(self, group_membership_pk=1):
@@ -347,11 +356,6 @@ class TestRemoveGroupMemberView(LoginRequiredMixin):
                 args=[group_membership.group.pk],
             ),
         )
-
-    def test_invalid_groupmembership(self, user_client):
-        """Test the view response for an invalid group membership."""
-        response = user_client.get(self._get_url(1))
-        assert response.status_code == HTTPStatus.NOT_FOUND
 
 
 class TestGetActiveUsersView:
@@ -428,7 +432,7 @@ class TestGetGroupDataView:
         assert response.content == expected
 
 
-class TestMakeGroupManagerView(LoginRequiredMixin):
+class TestMakeGroupManagerView(LoginRequiredMixin, GroupMembershipPKMixin):
     """Tests for the make group manager view."""
 
     def _get_url(self, group_membership_pk=1):
@@ -444,11 +448,6 @@ class TestMakeGroupManagerView(LoginRequiredMixin):
         response = client.get(self._get_url(pi_group_membership.pk))
         assert response.status_code == HTTPStatus.FORBIDDEN
         assert response.content == b"Permission denied"
-
-    def test_invalid_groupmembership(self, user_client):
-        """Test the view response for an invalid group membership."""
-        response = user_client.get(self._get_url(1))
-        assert response.status_code == HTTPStatus.NOT_FOUND
 
     def test_get(
         self,
@@ -484,7 +483,7 @@ class TestMakeGroupManagerView(LoginRequiredMixin):
         assert pi_group.owner.get_full_name() in email.body
 
 
-class TestRemoveGroupManagerView(LoginRequiredMixin):
+class TestRemoveGroupManagerView(LoginRequiredMixin, GroupMembershipPKMixin):
     """Tests for the remove group manager view."""
 
     def _get_url(self, group_membership_pk=1):
@@ -501,11 +500,6 @@ class TestRemoveGroupManagerView(LoginRequiredMixin):
         response = client.get(self._get_url(pi_group_manager.groupmembership.pk))
         assert response.status_code == HTTPStatus.FORBIDDEN
         assert response.content == b"Permission denied"
-
-    def test_invalid_groupmembership(self, user_client):
-        """Test the view response for an invalid group membership."""
-        response = user_client.get(self._get_url(1))
-        assert response.status_code == HTTPStatus.NOT_FOUND
 
     def test_successful_manager_removal(
         self,
@@ -541,7 +535,7 @@ class TestRemoveGroupManagerView(LoginRequiredMixin):
         assert pi_group_manager.get_full_name() in email.body
 
 
-class TestGroupMembershipExtendView(LoginRequiredMixin):
+class TestGroupMembershipExtendView(LoginRequiredMixin, GroupMembershipPKMixin):
     """Tests for the group membership extend view."""
 
     def _get_url(self, group_membership_pk=1):


### PR DESCRIPTION
# Description

This PR:
- takes a pass at the testing fixtures used for different roles and provides parametrised fixtures to run tests multiple times with different user roles.
- standarises and corrects the permissions applied to certain view functions and updates the tests to reflect these.
- introduces a new testing mixin for view functions that take a GroupMembership primary key as an argument.

These changes lay the groundwork for #140 and #131.

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [X] All tests pass (eg. `python -m pytest`)
- [ ] The documentation builds and looks OK (eg. `python -m sphinx -b html docs docs/build`)
- [X] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)

## Further checks

- [X] Code is commented, particularly in hard-to-understand areas
- [X] Tests added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
