### PR TITLE
Account for existing group members when adding new group members

### DIFF
--- a/imperial_coldfront_plugin/policy.py
+++ b/imperial_coldfront_plugin/policy.py
@@ -1,9 +1,10 @@
 """Policy functionality governing the eligibility of users access RCS systems."""
 
+from django.contrib.auth import get_user_model
 from django.core.exceptions import PermissionDenied
 from django.utils import timezone
 
-from .models import GroupMembership
+from .models import GroupMembership, ResearchGroup
 
 
 def _filter_entity_type(entity_type):
@@ -33,6 +34,20 @@ def user_eligible_for_hpc_access(user_profile):
                 user_profile["department"],
             ),
         ]
+    )
+
+
+def user_already_has_hpc_access(username):
+    """Check if the user is already a member of a ResearchGroup."""
+    User = get_user_model()
+    try:
+        user = User.objects.get(username=username)
+    except User.DoesNotExist:
+        return False
+    return (
+        user.is_superuser
+        or GroupMembership.objects.filter(member=user).exists()
+        or ResearchGroup.objects.filter(owner=user).exists()
     )
 
 

--- a/imperial_coldfront_plugin/templates/imperial_coldfront_plugin/user_search.html
+++ b/imperial_coldfront_plugin/templates/imperial_coldfront_plugin/user_search.html
@@ -5,6 +5,7 @@
     <input type="submit" value="Search" />
   </form>
   {% if search_results %}
+    <p>Please note that users that already a member of a</p>
     <form action="{% url 'imperial_coldfront_plugin:send_group_invite' group_pk %}"
           method="post">
       {% csrf_token %}

--- a/imperial_coldfront_plugin/views.py
+++ b/imperial_coldfront_plugin/views.py
@@ -153,6 +153,9 @@ def send_group_invite(request: HttpRequest, group_pk: int) -> HttpResponse:
                 return HttpResponseBadRequest("Expiration date should be in the future")
 
             username = form.cleaned_data["username"]
+            if GroupMembership.objects.filter(member__username=username):
+                return HttpResponseBadRequest("User already in a group")
+
             graph_client = get_graph_api_client()
             user_profile = graph_client.user_profile(username)
 

--- a/imperial_coldfront_plugin/views.py
+++ b/imperial_coldfront_plugin/views.py
@@ -112,8 +112,17 @@ def user_search(request: HttpRequest, group_pk: int) -> HttpResponse:
             search_query = form.cleaned_data["search"]
             graph_client = get_graph_api_client()
             search_results = graph_client.user_search(search_query)
+
+            group_memberships = GroupMembership.objects.filter(group__pk=group_pk)
+            group_members = [
+                membership.member.username for membership in group_memberships
+            ]
+
             filtered_results = [
-                user for user in search_results if user_eligible_for_hpc_access(user)
+                user
+                for user in search_results
+                if user_eligible_for_hpc_access(user)
+                and user["username"] not in group_members
             ]
             return render(
                 request,

--- a/tests/test_policy.py
+++ b/tests/test_policy.py
@@ -8,6 +8,7 @@ from imperial_coldfront_plugin.policy import (
     PI_DISALLOWED_TITLE_QUALIFIERS,
     check_group_owner_manager_or_superuser,
     check_group_owner_or_superuser,
+    user_already_has_hpc_access,
     user_eligible_for_hpc_access,
     user_eligible_to_be_pi,
 )
@@ -85,3 +86,27 @@ class TestCheckGroupOwnerOrSuperuser:
         """Test the check fails for a other users."""
         with pytest.raises(PermissionDenied):
             check_group_owner_or_superuser(pi_group, user_member_or_manager)
+
+def test_user_already_has_hpc_access_no_user(db):
+    """Test if non-existent user already has access."""
+    assert not user_already_has_hpc_access("username")
+
+
+def test_user_already_has_hpc_access(user):
+    """Test if a user already has access."""
+    assert not user_already_has_hpc_access(user.username)
+
+
+def test_user_already_has_hpc_access_group_membership(pi_group_member):
+    """Test if a user with a group membership already has access."""
+    assert user_already_has_hpc_access(pi_group_member.username)
+
+
+def test_user_already_has_hpc_access_group_owner(pi_group):
+    """Test if a user with a group ownership already has access."""
+    assert user_already_has_hpc_access(pi_group.owner.username)
+
+
+def test_user_already_has_hpc_access_superuser(superuser):
+    """Test if a superuser already has access."""
+    assert user_already_has_hpc_access(superuser.username)

--- a/tests/test_policy.py
+++ b/tests/test_policy.py
@@ -87,6 +87,7 @@ class TestCheckGroupOwnerOrSuperuser:
         with pytest.raises(PermissionDenied):
             check_group_owner_or_superuser(pi_group, user_member_or_manager)
 
+
 def test_user_already_has_hpc_access_no_user(db):
     """Test if non-existent user already has access."""
     assert not user_already_has_hpc_access("username")

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -206,6 +206,17 @@ class TestSendGroupInviteView(LoginRequiredMixin):
         assert response.content == b"Invalid data"
         assert len(mailoutbox) == 0
 
+    def test_user_already_in_group(self, pi_client, pi_group, research_group_factory):
+        """Test that a user who is already in the group cannot be invited."""
+        group, [membership] = research_group_factory(number_of_members=1)
+        data = {
+            "username": membership.member.username,
+            "expiration": timezone.datetime.max.date(),
+        }
+        response = pi_client.post(self._get_url(pi_group.pk), data=data)
+        assert response.status_code == HTTPStatus.BAD_REQUEST
+        assert response.content == b"User already in a group"
+
 
 class TestAcceptGroupInvite(LoginRequiredMixin):
     """Tests for the accept group invite view."""


### PR DESCRIPTION
# Description

If a user is already a member of a group then this PR means that they no longer appear in search results when adding new group members and prevents a new invitation being sent to them. This primarily a QoL change as the database schema already prevents them being added to another group.

Fixes #134 

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [X] All tests pass (eg. `python -m pytest`)
- [X] The documentation builds and looks OK (eg. `python -m sphinx -b html docs docs/build`)
- [X] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)

## Further checks

- [X] Code is commented, particularly in hard-to-understand areas
- [X] Tests added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
