### PR TITLE
Standardise view permission checks

### DIFF
--- a/imperial_coldfront_plugin/policy.py
+++ b/imperial_coldfront_plugin/policy.py
@@ -1,5 +1,10 @@
 """Policy functionality governing the eligibility of users access RCS systems."""
 
+from django.core.exceptions import PermissionDenied
+from django.utils import timezone
+
+from .models import GroupMembership
+
 
 def _filter_entity_type(entity_type):
     """Capture complex sublogic for filtering entity types."""
@@ -70,3 +75,21 @@ def user_eligible_to_be_pi(user_profile):
         return False
 
     return True
+
+
+def check_group_owner_manager_or_superuser(group, user):
+    """Check if the user is the owner or manager of the group or a superuser."""
+    if not (
+        group.owner == user
+        or user.is_superuser
+        or GroupMembership.objects.filter(
+            group=group, member=user, is_manager=True, expiration__gt=timezone.now()
+        ).exists()
+    ):
+        raise PermissionDenied
+
+
+def check_group_owner_or_superuser(group, user):
+    """Check if the user is the owner of the group or a superuser."""
+    if not (group.owner == user or user.is_superuser):
+        raise PermissionDenied

--- a/imperial_coldfront_plugin/views.py
+++ b/imperial_coldfront_plugin/views.py
@@ -31,7 +31,11 @@ from .forms import (
 )
 from .microsoft_graph_client import get_graph_api_client
 from .models import GroupMembership, ResearchGroup
-from .policy import user_eligible_for_hpc_access
+from .policy import (
+    check_group_owner_manager_or_superuser,
+    check_group_owner_or_superuser,
+    user_eligible_for_hpc_access,
+)
 
 User = get_user_model()
 
@@ -61,15 +65,7 @@ def group_members_view(request: HttpRequest, group_pk: int) -> HttpResponse:
         Http404: If no group is found with the provided `group_pk`.
     """
     group = get_object_or_404(ResearchGroup, pk=group_pk)
-
-    if (
-        request.user != group.owner
-        and not request.user.is_superuser
-        and not GroupMembership.objects.filter(
-            group=group, member=request.user, is_manager=True
-        ).exists()
-    ):
-        return HttpResponseForbidden("Permission denied")
+    check_group_owner_manager_or_superuser(group, request.user)
 
     group_members = GroupMembership.objects.filter(group=group)
     is_manager = group_members.filter(member=request.user, is_manager=True).exists()
@@ -136,14 +132,7 @@ def user_search(request: HttpRequest, group_pk: int) -> HttpResponse:
 def send_group_invite(request: HttpRequest, group_pk: int) -> HttpResponse:
     """Invite an individual to a group."""
     group = get_object_or_404(ResearchGroup, pk=group_pk)
-    if (
-        not request.user == group.owner
-        and not request.user.is_superuser
-        and not GroupMembership.objects.filter(
-            member=request.user, is_manager=True
-        ).exists()
-    ):
-        return HttpResponseForbidden("Permission denied")
+    check_group_owner_manager_or_superuser(group, request.user)
 
     if request.method == "POST":
         form = GroupMembershipForm(request.POST)
@@ -257,15 +246,7 @@ def remove_group_member(request: HttpRequest, group_membership_pk: int) -> HttpR
     """
     group_membership = get_object_or_404(GroupMembership, pk=group_membership_pk)
     group = group_membership.group
-
-    if (
-        request.user != group.owner
-        and not request.user.is_superuser
-        and not GroupMembership.objects.filter(
-            group=group, member=request.user, is_manager=True
-        ).exists()
-    ):
-        return HttpResponseForbidden("Permission denied")
+    check_group_owner_manager_or_superuser(group, request.user)
 
     if group_membership.member == request.user:
         return HttpResponseForbidden("You cannot remove yourself from the group.")
@@ -337,9 +318,7 @@ def make_group_manager(request: HttpRequest, group_membership_pk: int) -> HttpRe
     """
     group_membership = get_object_or_404(GroupMembership, pk=group_membership_pk)
     group = group_membership.group
-
-    if request.user != group.owner and not request.user.is_superuser:
-        return HttpResponseForbidden("Permission denied")
+    check_group_owner_or_superuser(group, request.user)
 
     group_membership.is_manager = True
     group_membership.save()
@@ -361,9 +340,7 @@ def remove_group_manager(
     """
     group_membership = get_object_or_404(GroupMembership, pk=group_membership_pk)
     group = group_membership.group
-
-    if request.user != group.owner and not request.user.is_superuser:
-        return HttpResponseForbidden("Permission denied")
+    check_group_owner_or_superuser(group, request.user)
 
     group_membership.is_manager = False
     group_membership.save()
@@ -386,17 +363,7 @@ def group_membership_extend(
     group_membership = get_object_or_404(GroupMembership, pk=group_membership_pk)
     group = group_membership.group
 
-    # Check if the accessing user is an owner/manager of the group in question
-    # (or a superadmin).
-
-    if (
-        request.user != group.owner
-        and not request.user.is_superuser
-        and not GroupMembership.objects.filter(
-            group=group, member=request.user, is_manager=True
-        ).exists()
-    ):
-        return HttpResponseForbidden("Permission denied")
+    check_group_owner_manager_or_superuser(group, request.user)
 
     if group_membership.member == request.user:
         return HttpResponseForbidden("You cannot extend your own membership.")

--- a/tests/test_policy.py
+++ b/tests/test_policy.py
@@ -1,9 +1,13 @@
 import pytest
+from django.core.exceptions import PermissionDenied
+from django.utils import timezone
 
 from imperial_coldfront_plugin.policy import (
     PI_ALLOWED_TITLES,
     PI_DISALLOWED_DEPARTMENTS,
     PI_DISALLOWED_TITLE_QUALIFIERS,
+    check_group_owner_manager_or_superuser,
+    check_group_owner_or_superuser,
     user_eligible_for_hpc_access,
     user_eligible_to_be_pi,
 )
@@ -48,3 +52,36 @@ def test_user_eligible_to_be_pi(job_title, pi_user_profile):
 def test_user_eligible_to_be_pi_invalid(override_key, override_value, pi_user_profile):
     """Test the pi filter catches invalid profiles."""
     assert not user_eligible_to_be_pi(pi_user_profile | {override_key: override_value})
+
+
+class TestCheckGroupOwnerManagerOrSuperuser:
+    """Tests for the check_group_owner_manager_or_superuser function."""
+
+    def test_pass(self, pi_group, pi_manager_or_superuser):
+        """Test the check passes for a group owner or manager or a superuser."""
+        check_group_owner_manager_or_superuser(pi_group, pi_manager_or_superuser)
+
+    def test_expired_manager(self, pi_group, pi_group_manager):
+        """Test the check fails for an expired manager."""
+        pi_group_manager.groupmembership.expiration = timezone.datetime.min
+        pi_group_manager.groupmembership.save()
+        with pytest.raises(PermissionDenied):
+            check_group_owner_manager_or_superuser(pi_group, pi_group_manager)
+
+    def test_user(self, pi_group, user_or_member):
+        """Test the check fails for other users."""
+        with pytest.raises(PermissionDenied):
+            check_group_owner_manager_or_superuser(pi_group, user_or_member)
+
+
+class TestCheckGroupOwnerOrSuperuser:
+    """Tests for the check_group_owner_or_superuser function."""
+
+    def test_pass(self, pi_group, pi_or_superuser):
+        """Check the group owner or superuser passes the check."""
+        check_group_owner_or_superuser(pi_group, pi_or_superuser)
+
+    def test_manager(self, pi_group, user_member_or_manager):
+        """Test the check fails for a other users."""
+        with pytest.raises(PermissionDenied):
+            check_group_owner_or_superuser(pi_group, user_member_or_manager)

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -59,7 +59,6 @@ class TestGroupMembersView(LoginRequiredMixin):
         """Test that unauthorised users cannot access the view."""
         response = auth_client_factory(user_or_member).get(self._get_url(pi_group.pk))
         assert response.status_code == HTTPStatus.FORBIDDEN
-        assert response.content == b"Permission denied"
 
     def test_get(self, auth_client_factory, pi_manager_or_superuser, pi_group):
         """Test the view for authorised users."""
@@ -128,7 +127,6 @@ class TestSendGroupInviteView(LoginRequiredMixin):
         client = auth_client_factory(user_or_member)
         response = client.post(self._get_url(pi_group.pk))
         assert response.status_code == HTTPStatus.FORBIDDEN
-        assert response.content == b"Permission denied"
 
     def test_post(
         self,
@@ -340,7 +338,6 @@ class TestRemoveGroupMemberView(LoginRequiredMixin, GroupMembershipPKMixin):
         client = auth_client_factory(user_or_member)
         response = client.get(self._get_url(pi_group_membership.pk))
         assert response.status_code == HTTPStatus.FORBIDDEN
-        assert response.content == b"Permission denied"
 
     def test_get(
         self, auth_client_factory, pi_manager_or_superuser, pi_group, pi_group_member
@@ -447,7 +444,6 @@ class TestMakeGroupManagerView(LoginRequiredMixin, GroupMembershipPKMixin):
         client = auth_client_factory(user_member_or_manager)
         response = client.get(self._get_url(pi_group_membership.pk))
         assert response.status_code == HTTPStatus.FORBIDDEN
-        assert response.content == b"Permission denied"
 
     def test_get(
         self,
@@ -499,7 +495,6 @@ class TestRemoveGroupManagerView(LoginRequiredMixin, GroupMembershipPKMixin):
         client = auth_client_factory(user_member_or_manager)
         response = client.get(self._get_url(pi_group_manager.groupmembership.pk))
         assert response.status_code == HTTPStatus.FORBIDDEN
-        assert response.content == b"Permission denied"
 
     def test_successful_manager_removal(
         self,
@@ -550,7 +545,6 @@ class TestGroupMembershipExtendView(LoginRequiredMixin, GroupMembershipPKMixin):
         client = auth_client_factory(user_or_member)
         response = client.get(self._get_url(pi_group_membership.pk))
         assert response.status_code == HTTPStatus.FORBIDDEN
-        assert response.content == b"Permission denied"
 
     def test_manager_cannot_extend_own_membership(
         self, pi_group_manager, auth_client_factory


### PR DESCRIPTION
# Description

This PR captures the common logic relating to permissions for different view functions. It also adds a check that a group managers membership has not expired.

Fixes #140 

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [X] All tests pass (eg. `python -m pytest`)
- [X] The documentation builds and looks OK (eg. `python -m sphinx -b html docs docs/build`)
- [X] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)

## Further checks

- [X] Code is commented, particularly in hard-to-understand areas
- [X] Tests added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
