### PR TITLE
Bug fix in case of being unable to access user profile data

### DIFF
--- a/imperial_coldfront_plugin/microsoft_graph_client.py
+++ b/imperial_coldfront_plugin/microsoft_graph_client.py
@@ -36,7 +36,7 @@ def _transform_profile_data(data):
         "record_status": extension_attributes.get("extensionAttribute5"),
         "name": data.get("displayName"),
         "email": data.get("mail"),
-        "username": data.get("userPrincipalName").removesuffix("@ic.ac.uk"),
+        "username": data.get("userPrincipalName", "").removesuffix("@ic.ac.uk"),
     }
 
 


### PR DESCRIPTION
# Description

Updates the `_transform_profile_data` function to prevent unhandled exceptions in the case of missing user profile data.

Fixes # (issue)

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [x] All tests pass (eg. `python -m pytest`)
- [x] The documentation builds and looks OK (eg. `python -m sphinx -b html docs docs/build`)
- [x] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
