### PR TITLE
Expired member cannot be made manager

### DIFF
--- a/imperial_coldfront_plugin/templates/group_members.html
+++ b/imperial_coldfront_plugin/templates/group_members.html
@@ -11,7 +11,7 @@
       <li>
         {{ member.member.get_full_name }} (expires {{ member.expiration }}) -
         <a href="{% url 'imperial_coldfront_plugin:remove_group_member' member.pk %}">Remove access</a>
-        {% if is_manager == False and member.is_manager == False %}
+        {% if is_manager == False and member.is_manager == False and member.expiration > current_date %}
           | <a href="{% url 'imperial_coldfront_plugin:make_manager' member.pk %}">Make manager</a>
         {% endif %}
         {% if member.is_manager and is_manager == False %}

--- a/imperial_coldfront_plugin/views.py
+++ b/imperial_coldfront_plugin/views.py
@@ -395,6 +395,9 @@ def make_group_manager(request: HttpRequest, group_membership_pk: int) -> HttpRe
     group = group_membership.group
     check_group_owner_or_superuser(group, request.user)
 
+    if group_membership.expiration.date() < timezone.now().date():
+        return HttpResponseForbidden("Membership has expired.")
+
     group_membership.is_manager = True
     group_membership.save()
 

--- a/imperial_coldfront_plugin/views.py
+++ b/imperial_coldfront_plugin/views.py
@@ -134,6 +134,7 @@ def group_members_view(request: HttpRequest, group_pk: int) -> HttpResponse:
 
     group_members = GroupMembership.objects.filter(group=group)
     is_manager = group_members.filter(member=request.user, is_manager=True).exists()
+    current_date = timezone.now()
 
     return render(
         request,
@@ -142,6 +143,7 @@ def group_members_view(request: HttpRequest, group_pk: int) -> HttpResponse:
             "group_members": group_members,
             "is_manager": is_manager,
             "group_pk": group_pk,
+            "current_date": current_date,
         },
     )
 

--- a/imperial_coldfront_plugin/views.py
+++ b/imperial_coldfront_plugin/views.py
@@ -396,7 +396,7 @@ def make_group_manager(request: HttpRequest, group_membership_pk: int) -> HttpRe
     check_group_owner_or_superuser(group, request.user)
 
     if group_membership.expiration.date() < timezone.now().date():
-        return HttpResponseForbidden("Membership has expired.")
+        return HttpResponseBadRequest("Membership has expired.")
 
     group_membership.is_manager = True
     group_membership.save()

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -507,6 +507,18 @@ class TestMakeGroupManagerView(LoginRequiredMixin, GroupMembershipPKMixin):
         assert pi_group_member.get_full_name() in email.body
         assert pi_group.owner.get_full_name() in email.body
 
+    def test_expired_membership(
+        self, auth_client_factory, pi_or_superuser, pi_group_membership
+    ):
+        """Test that an expired group membership cannot be made a manager."""
+        pi_group_membership.expiration = timezone.datetime.min.date()
+        pi_group_membership.save()
+
+        client = auth_client_factory(pi_or_superuser)
+        response = client.get(self._get_url(pi_group_membership.pk))
+        assert response.content == b"Membership has expired."
+        assert response.status_code == HTTPStatus.FORBIDDEN
+
 
 class TestRemoveGroupManagerView(LoginRequiredMixin, GroupMembershipPKMixin):
     """Tests for the remove group manager view."""

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -517,7 +517,7 @@ class TestMakeGroupManagerView(LoginRequiredMixin, GroupMembershipPKMixin):
         client = auth_client_factory(pi_or_superuser)
         response = client.get(self._get_url(pi_group_membership.pk))
         assert response.content == b"Membership has expired."
-        assert response.status_code == HTTPStatus.FORBIDDEN
+        assert response.status_code == HTTPStatus.BAD_REQUEST
 
 
 class TestRemoveGroupManagerView(LoginRequiredMixin, GroupMembershipPKMixin):


### PR DESCRIPTION
# Description

This pull request includes changes to handle that expired group memberships cannot be made managers.

Fixes #125 

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [x] All tests pass (eg. `python -m pytest`)
- [ ] The documentation builds and looks OK (eg. `python -m sphinx -b html docs docs/build`)
- [x] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [x] Tests added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
