### PR TITLE
Search by multiple fields

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# VSCode settings
+.vscode/

--- a/imperial_coldfront_plugin/microsoft_graph_client.py
+++ b/imperial_coldfront_plugin/microsoft_graph_client.py
@@ -60,9 +60,51 @@ def parse_profile_data_list(response):
     return [_transform_profile_data(item) for item in data]
 
 
+ATTRIBUTES_CONVERSION_TABLE = {
+    "job_title": "jobTitle",
+    "department": "department",
+    "company_name": "companyName",
+    "name": "displayName",
+    "email": "mail",
+    "username": "userPrincipalName",
+    "first_name": "givenName",
+    "last_name": "surname",
+}
+
+
+def build_user_search_query(
+    term: str | None = None, search_by: str = "all_fields"
+) -> str:
+    """Builds the URL query string.
+
+    It will have the form "search_field:search_term" if only one field is chosen or:
+    '"search_field_1:search_term" OR "search_field_2:search_term" OR ...' if the search
+    is in all fields.
+
+    Args:
+        term: The search term to look for.
+        search_by: The fields to search into. Defaults to all fields.
+
+    Returns:
+        The query string.
+    """
+    if search_by == "all_fields":
+        query = ""
+        for field in ATTRIBUTES_CONVERSION_TABLE.values():
+            extra = f'"{field}:{term}"'
+            if query:
+                query = f"({extra} OR {query})"
+            else:
+                query = extra
+        query = query[1:-1]
+    else:
+        query = f'"displayName:{term}" OR "userPrincipalName:{term}"'
+    return query
+
+
 PROFILE_ATTRIBUTES = (
-    "jobTitle,department,companyName,userType,onPremisesExtensionAttributes,displayName"
-    ",mail,userPrincipalName,givenName,surname"
+    ",".join(ATTRIBUTES_CONVERSION_TABLE.values())
+    + ",userType,onPremisesExtensionAttributes"
 )
 """The attributes to request when fetching user profile data."""
 
@@ -87,12 +129,24 @@ class MicrosoftGraphClient(Consumer):
 
     @response_handler(parse_profile_data_list)
     @headers(dict(ConsistencyLevel="eventual"))
-    @get(
-        'users?$search="displayName:{query}" OR "userPrincipalName:{query}"&$select='
-        + PROFILE_ATTRIBUTES
-    )
+    @get("users?$search={query}&$select=" + PROFILE_ATTRIBUTES)
     def user_search(self, query: str):
         """Search for a user by their display name or user principal name."""
+
+    def user_search_by(
+        self, user_search_string: str | None = None, search_by: str = "all_fields"
+    ) -> list[str]:
+        """Search within a specific field.
+
+        Args:
+            user_search_string: The search term to look for.
+            search_by: The fields to search into. Defaults to all fields.
+
+        Return:
+            List of users' information matching the query.
+        """
+        query = build_user_search_query(user_search_string, search_by)
+        return self.user_search(query)
 
 
 def get_graph_api_client(access_token=None):

--- a/imperial_coldfront_plugin/views.py
+++ b/imperial_coldfront_plugin/views.py
@@ -60,7 +60,7 @@ class GraphAPISearch(UserSearch):
                 user's name or username.
         """
         graph_client = get_graph_api_client()
-        found = graph_client.user_search(user_search_string)
+        found = graph_client.user_search_by(user_search_string, search_by)
         for user in found:
             user["source"] = self.search_source
         return list(filter(user_eligible_for_hpc_access, found))


### PR DESCRIPTION
# Description

Tentative implementation of searching by multiple fields, essentially, there are two options given what the UI offers: only username or all fields.

For the first one, I'm using the same search string as before, Eg.:

`"displayName:diego" OR "userPrincipalName:diego"`

For the second one I'm creating a more complex search string using all fields Eg.:

`"surname:diego" OR ("givenName:diego" OR ("userPrincipalName:diego" OR ("mail:diego" OR ("displayName:diego" OR ("userType:diego" OR ("companyName:diego" OR ("department:diego" OR "jobTitle:diego")))))))`

In principle, the second one does work and is well constructed as far as I understand [the instructions](https://learn.microsoft.com/en-us/graph/search-query-parameter?tabs=http#using-search-on-directory-object-collections), but it is odd since when searching for a term like `physics`, which should return every user in the department of physics who could use the HPC, I just get one entry.

So there's something not quite right yet, I think. 

Fixes #172

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [ ] All tests pass (eg. `python -m pytest`)
- [ ] The documentation builds and looks OK (eg. `python -m sphinx -b html docs docs/build`)
- [ ] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
