### PR TITLE
GPFS client: set quotas

### DIFF
--- a/imperial_coldfront_plugin/gpfs_client.py
+++ b/imperial_coldfront_plugin/gpfs_client.py
@@ -182,8 +182,10 @@ class GPFSClient(Consumer):
         Args:
             filesystem_name: Name of the filesystem where the quota will be set.
             fileset_name: Name of the fileset to set the quota.
-            block_quota: Block quota.
-            files_quota: Files quota.
+            block_quota: Number that specifies the block soft limit and hard
+                    limit. The number can be specified using the suffix K, M, G, or T.
+            files_quota: Number that specifies the inode soft limit and hard
+                    limit. The number can be specified using the suffix K, M, or G.
 
         Returns:
             The response after successfully setting the quota.

--- a/imperial_coldfront_plugin/gpfs_client.py
+++ b/imperial_coldfront_plugin/gpfs_client.py
@@ -159,3 +159,44 @@ class GPFSClient(Consumer):
             path=path,
             permissions=permissions,
         )
+
+    @check_job_status
+    @json
+    @post("filesystems/{filesystemName}/quotas")
+    def _set_quota(
+        self,
+        filesystemName: str,
+        **data: Body,
+    ) -> requests.Response:
+        """Method (private) to set a quota in the requested filesystem."""
+
+    def set_quota(
+        self,
+        filesystem_name: str,
+        fileset_name: str,
+        block_quota: str,
+        files_quota: str,
+    ) -> requests.Response:
+        """Method (public) to set a quota in the requested filesystem.
+
+        Args:
+            filesystem_name: Name of the filesystem where the quota will be set.
+            fileset_name: Name of the fileset to set the quota.
+            block_quota: Block quota.
+            files_quota: Files quota.
+
+        Returns:
+            The response after successfully setting the quota.
+        """
+        return self._set_quota(
+            filesystemName=filesystem_name,
+            objectName=fileset_name,
+            operationType="setQuota",
+            quotaType="FILESET",
+            blockSoftLimit=block_quota,
+            blockHardLimit=block_quota,
+            filesSoftLimit=files_quota,
+            filesHardLimit=files_quota,
+            filesGracePeriod="null",
+            blockGracePeriod="null",
+        )


### PR DESCRIPTION
# Description

This pull request adding methods to set quotas on filesystems. The changes include the addition of a private method `_set_quota` and a public method `set_quota`.

Fixes #182 

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [ ] All tests pass (eg. `python -m pytest`)
- [ ] The documentation builds and looks OK (eg. `python -m sphinx -b html docs docs/build`)
- [ ] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
