### PR TITLE
Add/Remove members from AD groups

### DIFF
--- a/imperial_coldfront_plugin/apps.py
+++ b/imperial_coldfront_plugin/apps.py
@@ -8,3 +8,7 @@ class ImperialColdfrontPluginConfig(AppConfig):
 
     default_auto_field = "django.db.models.BigAutoField"
     name = "imperial_coldfront_plugin"
+
+    def ready(self):
+        """Wire up signal handlers for app."""
+        from . import signals  # noqa: F401

--- a/imperial_coldfront_plugin/signals.py
+++ b/imperial_coldfront_plugin/signals.py
@@ -1,0 +1,61 @@
+"""Django signals."""
+
+from coldfront.core.allocation.models import AllocationAttribute, AllocationUser
+from django.conf import settings
+from django.db.models.signals import post_delete, post_save
+from django.dispatch import receiver
+
+from .ldap import (
+    ldap_add_member_to_group_in_background,
+    ldap_remove_member_from_group_in_background,
+)
+
+
+def _get_group_id_from_allocation(allocation):
+    try:
+        return allocation.allocationattribute_set.get(
+            allocation_attribute_type__name="RDF Project ID"
+        ).value
+    except AllocationAttribute.MultipleObjectsReturned:
+        raise ValueError(
+            f"Multiple RDF project ids found for allocation - {allocation}"
+        )
+    except AllocationAttribute.DoesNotExist:
+        return
+
+
+@receiver(post_save, sender=AllocationUser)
+def sync_ldap_group_membership(sender, instance, **kwargs):
+    """Add or remove members from an ldap group based on AllocationUser.status."""
+    if not settings.LDAP_ENABLED:
+        return
+
+    if (group_id := _get_group_id_from_allocation(instance.allocation)) is None:
+        return
+
+    if instance.status.name == "Active":
+        ldap_add_member_to_group_in_background(
+            group_id, instance.user.username, allow_already_present=True
+        )
+    else:
+        ldap_remove_member_from_group_in_background(
+            group_id, instance.user.username, allow_missing=True
+        )
+
+
+@receiver(post_delete, sender=AllocationUser)
+def remove_ldap_group_membership(sender, instance, **kwargs):
+    """Remove an ldap group member if the associated AllocationUser is deleted.
+
+    This isn't expected to come up in the usual course of things as removing a user via
+    the UI does not delete the AllocationUser object. Just cover it for completeness.
+    """
+    if not settings.LDAP_ENABLED:
+        return
+
+    if (group_id := _get_group_id_from_allocation(instance.allocation)) is None:
+        return
+
+    ldap_remove_member_from_group_in_background(
+        group_id, instance.user.username, allow_missing=True
+    )

--- a/tests/test_ldap.py
+++ b/tests/test_ldap.py
@@ -1,0 +1,84 @@
+import ldap3
+import pytest
+
+from imperial_coldfront_plugin.ldap import (
+    AD_ENTITY_ALREADY_EXISTS_ERROR_CODE,
+    AD_WILL_NOT_PERFORM_ERROR_CODE,
+    LDAPGroupModifyError,
+    _ldap_add_member_to_group,
+    _ldap_remove_member_from_group,
+    group_dn_from_name,
+)
+
+GROUP_NAME = "group_name"
+MEMBER_USERNAME = "user1"
+
+
+def test_ldap_add_member_to_group(ldap_connection_mock):
+    """Test _ldap_add_member_to_group."""
+    _ldap_add_member_to_group(GROUP_NAME, MEMBER_USERNAME)
+
+    ldap_connection_mock().modify.assert_called_once_with(
+        group_dn_from_name(GROUP_NAME),
+        dict(member=(ldap3.MODIFY_ADD, [MEMBER_USERNAME])),
+    )
+
+
+def test_ldap_add_member_to_group_allow_existing(ldap_connection_mock):
+    """Test allow_already_present option for _ldap_add_member_to_group."""
+    ldap_connection_mock().modify.return_value = (
+        False,
+        dict(result=AD_ENTITY_ALREADY_EXISTS_ERROR_CODE),
+        None,
+        None,
+    )
+
+    _ldap_add_member_to_group(GROUP_NAME, MEMBER_USERNAME, allow_already_present=True)
+
+
+def test_ldap_add_member_to_group_wrong_error_code(ldap_connection_mock):
+    """Test allow_already_present option if an incorrect error code is returned."""
+    ldap_connection_mock().modify.return_value = (
+        False,
+        dict(result=AD_ENTITY_ALREADY_EXISTS_ERROR_CODE + 1),
+        None,
+        None,
+    )
+    with pytest.raises(LDAPGroupModifyError):
+        _ldap_add_member_to_group(
+            GROUP_NAME, MEMBER_USERNAME, allow_already_present=True
+        )
+
+
+def test_ldap_remove_member_from_group(ldap_connection_mock):
+    """Test _ldap_remove_member_from_group."""
+    _ldap_remove_member_from_group(GROUP_NAME, MEMBER_USERNAME)
+
+    ldap_connection_mock().modify.assert_called_once_with(
+        group_dn_from_name(GROUP_NAME),
+        dict(member=(ldap3.MODIFY_DELETE, [MEMBER_USERNAME])),
+    )
+
+
+def test_ldap_remove_member_from_group_allow_missing(ldap_connection_mock):
+    """Test allow_missing option for _ldap_remove_member_from_group."""
+    ldap_connection_mock().modify.return_value = (
+        False,
+        dict(result=AD_WILL_NOT_PERFORM_ERROR_CODE),
+        None,
+        None,
+    )
+
+    _ldap_remove_member_from_group(GROUP_NAME, MEMBER_USERNAME, allow_missing=True)
+
+
+def test_ldap_remove_member_from_group_wrong_error_code(ldap_connection_mock):
+    """Test allow_missing option if an incorrect error code is returned."""
+    ldap_connection_mock().modify.return_value = (
+        False,
+        dict(result=AD_WILL_NOT_PERFORM_ERROR_CODE + 1),
+        None,
+        None,
+    )
+    with pytest.raises(LDAPGroupModifyError):
+        _ldap_remove_member_from_group(GROUP_NAME, MEMBER_USERNAME, allow_missing=True)

--- a/tests/test_signals.py
+++ b/tests/test_signals.py
@@ -1,0 +1,97 @@
+import pytest
+from coldfront.core.allocation.models import AllocationUser, AllocationUserStatusChoice
+
+
+@pytest.fixture
+def ldap_add_member_mock(mocker):
+    """Mock ldap_add_member_to_group_in_background in signals.py."""
+    return mocker.patch(
+        "imperial_coldfront_plugin.signals.ldap_add_member_to_group_in_background"
+    )
+
+
+@pytest.fixture
+def ldap_remove_member_mock(mocker):
+    """Mock ldap_remove_member_from_group_in_background in signals.py."""
+    return mocker.patch(
+        "imperial_coldfront_plugin.signals.ldap_remove_member_from_group_in_background"
+    )
+
+
+def test_sync_ldap_group_membership(
+    ldap_remove_member_mock,
+    ldap_add_member_mock,
+    pi,
+    rdf_allocation_project_id,
+    allocation_user,
+):
+    """Test sync_ldap_group_membership signal."""
+    ldap_add_member_mock.assert_called_once_with(
+        rdf_allocation_project_id, pi.username, allow_already_present=True
+    )
+    ldap_remove_member_mock.assert_not_called()
+
+    allocation_user_inactive_status = AllocationUserStatusChoice.objects.create(
+        name="Inactive"
+    )
+    allocation_user.status = allocation_user_inactive_status
+    allocation_user.save()
+
+    ldap_add_member_mock.assert_called_once()
+    ldap_remove_member_mock.assert_called_once_with(
+        rdf_allocation_project_id, pi.username, allow_missing=True
+    )
+
+
+def test_sync_ldap_group_membership_no_project_id(
+    ldap_remove_member_mock,
+    ldap_add_member_mock,
+    pi,
+    rdf_allocation,
+    rdf_allocation_project_id,
+    allocation_user_active_status,
+):
+    """Test sync_ldap_group_membership signal for non-rdf allocations."""
+    rdf_allocation.allocationattribute_set.get(
+        allocation_attribute_type__name="RDF Project ID"
+    ).delete()
+    allocation_user = AllocationUser.objects.create(
+        allocation=rdf_allocation,
+        user=pi,
+        status=allocation_user_active_status,
+    )
+
+    ldap_add_member_mock.assert_not_called()
+    ldap_remove_member_mock.assert_not_called()
+
+    allocation_user.delete()
+
+    ldap_add_member_mock.assert_not_called()
+    ldap_remove_member_mock.assert_not_called()
+
+
+def test_remove_ldap_group_membership(
+    ldap_remove_member_mock,
+    rdf_allocation_project_id,
+    allocation_user,
+    pi,
+):
+    """Test remove_ldap_group_membership signal."""
+    ldap_remove_member_mock.assert_not_called()
+
+    allocation_user.delete()
+
+    ldap_remove_member_mock(
+        rdf_allocation_project_id, pi.username, allowing_missing=True
+    )
+
+
+def test_remove_ldap_group_membership_no_project_id(
+    ldap_remove_member_mock, pi, rdf_allocation, allocation_user
+):
+    """Test remove_ldap_group_membership_signal for non-rdf allocation."""
+    rdf_allocation.allocationattribute_set.get(
+        allocation_attribute_type__name="RDF Project ID"
+    ).delete()
+    allocation_user.delete()
+    ldap_remove_member_mock.assert_not_called()


### PR DESCRIPTION
# Description

This PR adds the logic to syncronise the assigned of users to allocations within Coldfront with membership of the relevant group in active directory. It provides:

- ldap utility functionality to get a users [DN](https://learn.microsoft.com/en-us/previous-versions/windows/desktop/ldap/distinguished-names) (distinguished name) from their imperial username.
- ldap functions to add/remove members to/from a group.
- a pair of signals that handle syncing changes in the Coldfront database with the LDAP server.

Similarly to #177 there is unfortunately no way to try this out locally at the moment.

Fixes #167 #168 

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [X] All tests pass (eg. `python -m pytest`)
- [ ] The documentation builds and looks OK (eg. `python -m sphinx -b html docs docs/build`)
- [X] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)

## Further checks

- [X] Code is commented, particularly in hard-to-understand areas
- [X] Tests added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
