### PR TITLE
Add DART id to `RDFAllocation`

### DIFF
--- a/imperial_coldfront_plugin/forms.py
+++ b/imperial_coldfront_plugin/forms.py
@@ -71,8 +71,6 @@ class RDFAllocationForm(forms.Form):
         validators=[MinValueValidator(1)], help_text="In gigabytes"
     )
     dart_id = forms.CharField(
-        label="DART ID",
         help_text="The associated DART entry.",
-        disabled=True,
-        required=False,
+        disabled=False,
     )

--- a/imperial_coldfront_plugin/forms.py
+++ b/imperial_coldfront_plugin/forms.py
@@ -74,5 +74,4 @@ class RDFAllocationForm(forms.Form):
         label="DART ID",
         help_text="The associated DART entry.",
         disabled=True,
-        required=True,
     )

--- a/imperial_coldfront_plugin/forms.py
+++ b/imperial_coldfront_plugin/forms.py
@@ -70,3 +70,9 @@ class RDFAllocationForm(forms.Form):
     size = forms.IntegerField(
         validators=[MinValueValidator(1)], help_text="In gigabytes"
     )
+    dart_id = forms.CharField(
+        label="DART ID",
+        help_text="The associated DART entry.",
+        disabled=True,
+        required=True,
+    )

--- a/imperial_coldfront_plugin/forms.py
+++ b/imperial_coldfront_plugin/forms.py
@@ -74,4 +74,5 @@ class RDFAllocationForm(forms.Form):
         label="DART ID",
         help_text="The associated DART entry.",
         disabled=True,
+        required=False,
     )

--- a/imperial_coldfront_plugin/migrations/0010_auto_20250228_1431.py
+++ b/imperial_coldfront_plugin/migrations/0010_auto_20250228_1431.py
@@ -2,6 +2,7 @@
 
 from django.db import migrations
 
+
 def add_rdf_resource_type(apps, schema_editor):
     Resource = apps.get_model("resource", "Resource")
     ResourceType = apps.get_model("resource", "ResourceType")
@@ -21,7 +22,7 @@ def add_rdf_resource_type(apps, schema_editor):
             is_public=True,
             requires_payment=False,
             resource_type=storage_resource_type,
-        )
+        ),
     )
 
     text_attribute_type, _ = AttributeType.objects.get_or_create(name="Text")
@@ -32,18 +33,25 @@ def add_rdf_resource_type(apps, schema_editor):
             is_unique=True,
             is_private=True,
             is_changeable=False,
-        )
+        ),
     )
 
-
+    AllocationAttributeType.objects.get_or_create(
+        name="DART ID",
+        defaults=dict(
+            attribute_type=text_attribute_type,
+            is_unique=True,
+            is_changeable=False,
+        ),
+    )
 
 
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('imperial_coldfront_plugin', '0009_schedule_expiry_notification'),
-        ('resource', '0002_auto_20191017_1141'),
-        ('allocation', '0005_auto_20211117_1413'),
+        ("imperial_coldfront_plugin", "0009_schedule_expiry_notification"),
+        ("resource", "0002_auto_20191017_1141"),
+        ("allocation", "0005_auto_20211117_1413"),
     ]
 
     operations = [

--- a/imperial_coldfront_plugin/views.py
+++ b/imperial_coldfront_plugin/views.py
@@ -546,6 +546,7 @@ def add_rdf_storage_allocation(request):
             storage_size_gb = form.cleaned_data["size"]
             faculty = form.cleaned_data["faculty"]
             department = form.cleaned_data["department"]
+            dart_id = form.cleaned_data["dart_id"]
 
             rdf_id_attribute_type = AllocationAttributeType.objects.get(
                 name="RDF Project ID"
@@ -556,6 +557,13 @@ def add_rdf_storage_allocation(request):
                 value=project_id,
             ):
                 raise ValueError("RDF project with ID already exists.")
+
+            dart_id_attribute_type = AllocationAttributeType.objects.get(name="DART ID")
+            if AllocationAttribute.objects.filter(
+                allocation_attribute_type=dart_id_attribute_type,
+                value=dart_id,
+            ):
+                raise ValueError("DART ID already exists.")
 
             rdf_resource = Resource.objects.get(name="RDF Project Storage Space")
 

--- a/imperial_coldfront_plugin/views.py
+++ b/imperial_coldfront_plugin/views.py
@@ -559,7 +559,7 @@ def add_rdf_storage_allocation(request):
                 raise ValueError("RDF project with ID already exists.")
 
             dart_id_attribute_type = AllocationAttributeType.objects.get(
-                name="DART ID", is_private=True
+                name="DART ID", is_changeable=False
             )
             if AllocationAttribute.objects.filter(
                 allocation_attribute_type=dart_id_attribute_type,

--- a/imperial_coldfront_plugin/views.py
+++ b/imperial_coldfront_plugin/views.py
@@ -558,7 +558,9 @@ def add_rdf_storage_allocation(request):
             ):
                 raise ValueError("RDF project with ID already exists.")
 
-            dart_id_attribute_type = AllocationAttributeType.objects.get(name="DART ID")
+            dart_id_attribute_type = AllocationAttributeType.objects.get(
+                name="DART ID", is_private=True
+            )
             if AllocationAttribute.objects.filter(
                 allocation_attribute_type=dart_id_attribute_type,
                 value=dart_id,

--- a/imperial_coldfront_plugin/views.py
+++ b/imperial_coldfront_plugin/views.py
@@ -595,6 +595,12 @@ def add_rdf_storage_allocation(request):
                 value=project_id,
             )
 
+            AllocationAttribute.objects.create(
+                allocation_attribute_type=dart_id_attribute_type,
+                allocation=rdf_allocation,
+                value=dart_id,
+            )
+
             if settings.LDAP_ENABLED:
                 ldap_create_group_in_background(project_id)
 

--- a/imperial_coldfront_plugin/views.py
+++ b/imperial_coldfront_plugin/views.py
@@ -558,15 +558,6 @@ def add_rdf_storage_allocation(request):
             ):
                 raise ValueError("RDF project with ID already exists.")
 
-            dart_id_attribute_type = AllocationAttributeType.objects.get(
-                name="DART ID", is_changeable=False
-            )
-            if AllocationAttribute.objects.filter(
-                allocation_attribute_type=dart_id_attribute_type,
-                value=dart_id,
-            ):
-                raise ValueError("DART ID already exists.")
-
             rdf_resource = Resource.objects.get(name="RDF Project Storage Space")
 
             allocation_active_status = AllocationStatusChoice.objects.get(name="Active")
@@ -595,6 +586,9 @@ def add_rdf_storage_allocation(request):
                 value=project_id,
             )
 
+            dart_id_attribute_type = AllocationAttributeType.objects.get(
+                name="DART ID", is_changeable=False
+            )
             AllocationAttribute.objects.create(
                 allocation_attribute_type=dart_id_attribute_type,
                 allocation=rdf_allocation,

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -846,6 +846,7 @@ class TestAddRDFStorageAllocation(LoginRequiredMixin):
         size = 10
         faculty = "faculty"
         department = "department"
+        dart_id = "dart_id"
         response = superuser_client.post(
             self._get_url(),
             data=dict(
@@ -854,6 +855,7 @@ class TestAddRDFStorageAllocation(LoginRequiredMixin):
                 size=size,
                 department=department,
                 faculty=faculty,
+                dart_id=dart_id,
             ),
         )
         assertRedirects(response, reverse("home"), fetch_redirect_response=False)

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -884,6 +884,11 @@ class TestAddRDFStorageAllocation(LoginRequiredMixin):
             allocation=allocation,
             value=format_project_number_to_id(1),
         )
+        AllocationAttribute.objects.get(
+            allocation_attribute_type__name="DART ID",
+            allocation=allocation,
+            value=dart_id,
+        )
         AllocationUser.objects.get(
             allocation=allocation, user=pi_project.pi, status__name="Active"
         )


### PR DESCRIPTION
# Description

This pull request adds a `dart_id` field to the `RDFAllocationForm` class which is not  editable by end users.

Fixes #196 

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [ ] All tests pass (eg. `python -m pytest`)
- [ ] The documentation builds and looks OK (eg. `python -m sphinx -b html docs docs/build`)
- [ ] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
