### PR TITLE
Rename RDF resource to "RDF Active"

### DIFF
--- a/imperial_coldfront_plugin/ldap.py
+++ b/imperial_coldfront_plugin/ldap.py
@@ -138,7 +138,7 @@ def check_ldap_consistency():
     """Check the consistency of LDAP groups with the database."""
     discrepancies = []
     allocations = Allocation.objects.filter(
-        resources__name="RDF Project Storage Space",
+        resources__name="RDF Active",
         status__name="Active",
         allocationattribute__allocation_attribute_type__name="RDF Project ID",
     ).distinct()

--- a/imperial_coldfront_plugin/migrations/0010_auto_20250228_1431.py
+++ b/imperial_coldfront_plugin/migrations/0010_auto_20250228_1431.py
@@ -14,9 +14,9 @@ def add_rdf_resource_type(apps, schema_editor):
         defaults=dict(description="NAS storage"),
     )
     Resource.objects.get_or_create(
-        name="RDF Project Storage Space",
+        name="RDF Active",
         defaults=dict(
-            description="Storage space associated with a project on the RDF.",
+            description="Storage space associated with a research group on the RDF.",
             is_allocatable=False,
             is_available=True,
             is_public=True,

--- a/imperial_coldfront_plugin/views.py
+++ b/imperial_coldfront_plugin/views.py
@@ -521,7 +521,7 @@ def add_rdf_storage_allocation(request):
             ):
                 raise ValueError("RDF project with ID already exists.")
 
-            rdf_resource = Resource.objects.get(name="RDF Project Storage Space")
+            rdf_resource = Resource.objects.get(name="RDF Active")
 
             allocation_active_status = AllocationStatusChoice.objects.get(name="Active")
             project = get_object_or_404(Project, pk=form.cleaned_data["project"])

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -385,7 +385,7 @@ def rdf_allocation(pi_project, rdf_allocation_dependencies, rdf_allocation_proje
     )
     from coldfront.core.resource.models import Resource
 
-    rdf_resource = Resource.objects.get(name="RDF Project Storage Space")
+    rdf_resource = Resource.objects.get(name="RDF Active")
     rdf_id_attribute_type = AllocationAttributeType.objects.get(name="RDF Project ID")
 
     allocation_active_status = AllocationStatusChoice.objects.get(name="Active")


### PR DESCRIPTION
# Description

For simplicity and consistency this PR renames the RDF storage resource type from "RDF Project Storage Space" to "RDF Active". This should be clearer to users as "RDF Active" is the name of the actual service they're consuming. Note this is a bit naughty to modify the existing data migration. You'll need to wipe the existing database (`docker compose down -v`) to get a consistent state after this PR is merged.

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Breaking change (whatever its nature)

## Key checklist

- [X] All tests pass (eg. `python -m pytest`)
- [X] The documentation builds and looks OK (eg. `python -m sphinx -b html docs docs/build`)
- [X] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
