### PR TITLE
More sophisticated treatment of Dart ID's

### DIFF
--- a/imperial_coldfront_plugin/dart.py
+++ b/imperial_coldfront_plugin/dart.py
@@ -24,7 +24,7 @@ def validate_dart_id(dart_id: str):
         raise DartIDValidationError("Dart ID already assigned to an allocation")
 
 
-def create_dart_id_attribute(dart_id: int, allocation: Allocation):
+def create_dart_id_attribute(dart_id: str, allocation: Allocation):
     """Create an AllocationAttribute for a Dart ID."""
     validate_dart_id(dart_id)
     dart_id_attribute_type = AllocationAttributeType.objects.get(

--- a/imperial_coldfront_plugin/dart.py
+++ b/imperial_coldfront_plugin/dart.py
@@ -1,0 +1,37 @@
+"""Module for creation and validation of Dart ID AllocationAttribute's."""
+
+from coldfront.core.allocation.models import (
+    Allocation,
+    AllocationAttribute,
+    AllocationAttributeType,
+)
+
+
+class DartIDValidationError(Exception):
+    """Error when a Dart ID does not meet validation criteria."""
+
+
+def validate_dart_id(dart_id: str):
+    """Validate range and availability of Dart ID value."""
+    try:
+        if int(dart_id) < 1:
+            raise DartIDValidationError("Dart ID outside valid range")
+    except ValueError:
+        raise DartIDValidationError("Dart ID is not a number")
+    if AllocationAttribute.objects.filter(
+        allocation_attribute_type__name="DART ID", value=dart_id
+    ):
+        raise DartIDValidationError("Dart ID already assigned to an allocation")
+
+
+def create_dart_id_attribute(dart_id: int, allocation: Allocation):
+    """Create an AllocationAttribute for a Dart ID."""
+    validate_dart_id(dart_id)
+    dart_id_attribute_type = AllocationAttributeType.objects.get(
+        name="DART ID", is_changeable=False
+    )
+    return AllocationAttribute.objects.create(
+        allocation_attribute_type=dart_id_attribute_type,
+        allocation=allocation,
+        value=dart_id,
+    )

--- a/imperial_coldfront_plugin/forms.py
+++ b/imperial_coldfront_plugin/forms.py
@@ -142,3 +142,18 @@ class RDFAllocationForm(forms.Form):
         department_id = cleaned_data["department"]
         if department_id not in DEPARTMENTS_IN_FACULTY[faculty_id]:
             raise ValidationError("Invalid faculty and department combination.")
+
+
+class DartIDForm(forms.Form):
+    """Form for collection of a Dart ID value."""
+
+    dart_id = forms.CharField(disabled=False)
+
+    def clean_dart_id(self) -> str:
+        """Validate provided Dart ID."""
+        dart_id = self.cleaned_data["dart_id"]
+        try:
+            validate_dart_id(dart_id)
+        except DartIDValidationError as e:
+            raise ValidationError(e.args[0])
+        return dart_id

--- a/imperial_coldfront_plugin/forms.py
+++ b/imperial_coldfront_plugin/forms.py
@@ -10,6 +10,8 @@ from django.core.exceptions import ValidationError
 from django.core.validators import MinValueValidator
 from django.utils import timezone
 
+from .dart import DartIDValidationError, validate_dart_id
+
 
 class GroupMembershipForm(forms.Form):
     """Form for inviting a user to a research group."""
@@ -119,6 +121,15 @@ class RDFAllocationForm(forms.Form):
         help_text="The associated DART entry.",
         disabled=False,
     )
+
+    def clean_dart_id(self) -> str:
+        """Validate provided Dart ID."""
+        dart_id = self.cleaned_data["dart_id"]
+        try:
+            validate_dart_id(dart_id)
+        except DartIDValidationError as e:
+            raise ValidationError(e.args[0])
+        return dart_id
 
     def clean(self) -> bool:
         """Check if the faculty and department combination is valid.

--- a/imperial_coldfront_plugin/migrations/0010_auto_20250228_1431.py
+++ b/imperial_coldfront_plugin/migrations/0010_auto_20250228_1431.py
@@ -42,6 +42,7 @@ def add_rdf_resource_type(apps, schema_editor):
             attribute_type=text_attribute_type,
             is_unique=False,
             is_changeable=False,
+            is_private=False,
         ),
     )
 

--- a/imperial_coldfront_plugin/policy.py
+++ b/imperial_coldfront_plugin/policy.py
@@ -174,3 +174,9 @@ def check_group_owner_or_superuser(group, user):
     """Check if the user is the owner of the group or a superuser."""
     if not (group.owner == user or user.is_superuser):
         raise PermissionDenied
+
+
+def check_project_pi_or_superuser(project, user):
+    """Check if the user is the owner of the project or a superuser."""
+    if not (user.is_superuser or user == project.pi):
+        raise PermissionDenied

--- a/imperial_coldfront_plugin/templates/imperial_coldfront_plugin/dart_id_form.html
+++ b/imperial_coldfront_plugin/templates/imperial_coldfront_plugin/dart_id_form.html
@@ -1,0 +1,20 @@
+{% extends "common/base.html" %}
+{% load crispy_forms_tags %}
+{% block content %}
+  <div class="container mt-4">
+    <div class="card">
+      <div class="card-header">
+        <h2>Add Dart ID to Allocation</h2>
+      </div>
+      <div class="card-body">
+        <form method="post">
+          {% csrf_token %}
+          {{ form|crispy }}
+          <div class="mt-4">
+            <button type="submit" class="btn btn-primary">Create</button>
+          </div>
+        </form>
+      </div>
+    </div>
+  </div>
+{% endblock content %}

--- a/imperial_coldfront_plugin/urls.py
+++ b/imperial_coldfront_plugin/urls.py
@@ -69,4 +69,9 @@ urlpatterns = [
         views.task_stat_view,
         name="list_tasks",
     ),
+    path(
+        "add_dart_id/<int:allocation_pk>/",
+        views.add_dart_id_to_allocation,
+        name="add_dart_id",
+    ),
 ]

--- a/imperial_coldfront_plugin/views.py
+++ b/imperial_coldfront_plugin/views.py
@@ -38,6 +38,7 @@ from django.urls import reverse
 from django.utils import timezone
 from django_q.tasks import Chain, Task
 
+from .dart import create_dart_id_attribute
 from .emails import (
     send_group_access_granted_email,
     send_group_invite_email,
@@ -576,14 +577,7 @@ def add_rdf_storage_allocation(request):
                 value=project_id,
             )
 
-            dart_id_attribute_type = AllocationAttributeType.objects.get(
-                name="DART ID", is_changeable=False
-            )
-            AllocationAttribute.objects.create(
-                allocation_attribute_type=dart_id_attribute_type,
-                allocation=rdf_allocation,
-                value=dart_id,
-            )
+            create_dart_id_attribute(dart_id, rdf_allocation)
 
             chain = Chain()
             if settings.LDAP_ENABLED:

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -70,3 +70,11 @@ def test_rdf_allocation_form_clean_invalid_combination(rdf_form_data):
     form = RDFAllocationForm(data=rdf_form_data)
     assert not form.is_valid()
     assert form.errors == dict(__all__=["Invalid faculty and department combination."])
+
+
+def test_rdf_allocation_form_invalid_dart_id(rdf_form_data):
+    """Test that validation is being applied to dart_id field."""
+    rdf_form_data["dart_id"] = "-1"
+    form = RDFAllocationForm(data=rdf_form_data)
+    assert not form.is_valid()
+    assert form.errors == dict(dart_id=["Dart ID outside valid range"])

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -812,7 +812,7 @@ class TestAddRDFStorageAllocation(LoginRequiredMixin):
         size = 10
         faculty = "foe"
         department = "dsde"
-        dart_id = "dart_id"
+        dart_id = "1001"
         group_name = get_next_rdf_project_id()
 
         response = superuser_client.post(


### PR DESCRIPTION
# Description

Validates and prevents duplicates of Dart ID values set as AllocationAttributes. Also provides a dedicated route for users/superusers to add additional Dart ID's to an allocation. Also updates the `DART ID` AllocationAttributeType to not be private.

Fixes # (issue)

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [X] All tests pass (eg. `python -m pytest`)
- [ ] The documentation builds and looks OK (eg. `python -m sphinx -b html docs docs/build`)
- [X] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [x] Tests added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
