### PR TITLE
Signal refactor

### DIFF
--- a/imperial_coldfront_plugin/apps.py
+++ b/imperial_coldfront_plugin/apps.py
@@ -17,10 +17,10 @@ class ImperialColdfrontPluginConfig(AppConfig):
         """Wire up signal handlers for app."""
         from django.conf import settings
 
+        django_stubs_ext.monkeypatch()
+
         from . import signals  # noqa: F401
         from .gid import validate_gid_ranges
-
-        django_stubs_ext.monkeypatch()
 
         # Ensure GID_RANGES setting is valid
         # do it here to avoid circular import issues

--- a/imperial_coldfront_plugin/signals.py
+++ b/imperial_coldfront_plugin/signals.py
@@ -23,10 +23,11 @@ from .ldap import (
     ldap_gid_in_use,
     ldap_remove_member_from_group,
 )
+from .tasks import remove_allocation_group_members
 
 
 @receiver(pre_save, sender=AllocationAttribute)
-def ensure_no_existing_gid(
+def allocation_attribute_ensure_no_existing_gid(
     sender: object, instance: AllocationAttribute, **kwargs: object
 ) -> None:
     """Prevent saving of GID attribute if it is already in use.
@@ -56,7 +57,7 @@ def ensure_no_existing_gid(
 
 
 @receiver(pre_save, sender=AllocationAttribute)
-def ensure_unique_shortname(
+def allocation_attribute_ensure_unique_shortname(
     sender: object, instance: AllocationAttribute, **kwargs: object
 ) -> None:
     """Prevent saving of shortname attribute if it is not unique.
@@ -76,7 +77,7 @@ def ensure_unique_shortname(
 
 
 @receiver(pre_save, sender=ProjectAttribute)
-def ensure_unique_group_id(
+def project_attribute_ensure_unique_group_id(
     sender: object, instance: ProjectAttribute, **kwargs: object
 ) -> None:
     """Prevent saving of project group name if it is not unique.
@@ -93,7 +94,7 @@ def ensure_unique_group_id(
 
 
 @receiver(post_save, sender=AllocationUser)
-def sync_ldap_group_membership(
+def allocation_user_sync_ldap_group_membership(
     sender: object, instance: AllocationUser, **kwargs: object
 ) -> None:
     """Add or remove members from an ldap group based on AllocationUser.status.
@@ -118,6 +119,10 @@ def sync_ldap_group_membership(
 
     shortname = rdf_allocation.ldap_shortname
 
+    if instance.allocation.status.name != "Active":
+        # Only manage LDAP group membership for Active allocations
+        return
+
     if instance.status.name == "Active":
         async_task(
             ldap_add_member_to_group,
@@ -135,7 +140,7 @@ def sync_ldap_group_membership(
 
 
 @receiver(post_delete, sender=AllocationUser)
-def remove_ldap_group_membership(
+def allocation_user_ldap_group_membership_deletion(
     sender: object, instance: AllocationUser, **kwargs: object
 ) -> None:
     """Remove an ldap group member if the associated AllocationUser is deleted.
@@ -163,6 +168,10 @@ def remove_ldap_group_membership(
 
     shortname = rdf_allocation.ldap_shortname
 
+    if instance.allocation.status.name != "Active":
+        # Only manage LDAP group membership for Active allocations
+        return
+
     async_task(
         ldap_remove_member_from_group,
         shortname,
@@ -173,15 +182,13 @@ def remove_ldap_group_membership(
 
 @receiver(post_save, sender=Allocation)
 @receiver(post_save, sender=RDFAllocation)
-def remove_ldap_group_members_if_allocation_inactive(
+def allocation_remove_ldap_group_members_if_inactive(
     sender: object, instance: Allocation | RDFAllocation, **kwargs: object
 ) -> None:
     """Remove all LDAP group members if allocation is not Active.
 
     The LDAP group itself is not deleted.
     """
-    from .tasks import remove_allocation_group_members
-
     if not settings.LDAP_ENABLED:
         return
     try:
@@ -198,7 +205,7 @@ def remove_ldap_group_members_if_allocation_inactive(
 
 @receiver(pre_save, sender=RDFAllocation)
 @receiver(pre_save, sender=Allocation)
-def allocation_expired_handler(
+def allocation_expiry_zero_quota(
     sender: type[RDFAllocation],
     instance: Allocation | RDFAllocation,
     **kwargs: object,
@@ -208,9 +215,6 @@ def allocation_expired_handler(
         return
 
     if instance.status.name != "Expired":
-        return
-
-    if not instance.resources.filter(name="RDF Active").exists():
         return
 
     try:
@@ -223,7 +227,7 @@ def allocation_expired_handler(
     except RDFAllocation.DoesNotExist:
         return
 
-    if old_instance.status == instance.status:
+    if old_instance.status.name != "Active":
         return
 
     async_task(

--- a/imperial_coldfront_plugin/signals.py
+++ b/imperial_coldfront_plugin/signals.py
@@ -48,7 +48,7 @@ def allocation_attribute_ensure_no_existing_gid(
         return
     if AllocationAttribute.objects.filter(
         allocation_attribute_type__name="GID", value=instance.value
-    ):
+    ).exists():
         raise ValueError(
             f"GID {instance.value} is already assigned to another allocation."
         )
@@ -71,7 +71,7 @@ def allocation_attribute_ensure_unique_shortname(
         instance.allocation_attribute_type.name == "Shortname"
         and AllocationAttribute.objects.filter(
             allocation_attribute_type__name="Shortname", value=instance.value
-        )
+        ).exists()
     ):
         raise ValueError(f"An allocation with {instance.value} already exists.")
 
@@ -87,8 +87,11 @@ def project_attribute_ensure_unique_group_id(
         instance: The instance being saved.
         **kwargs: Additional keyword arguments.
     """
-    if instance.proj_attr_type.name == "Group ID" and ProjectAttribute.objects.filter(
-        proj_attr_type__name="Group ID", value=instance.value
+    if (
+        instance.proj_attr_type.name == "Group ID"
+        and ProjectAttribute.objects.filter(
+            proj_attr_type__name="Group ID", value=instance.value
+        ).exists()
     ):
         raise ValueError(f"A project with {instance.value} already exists.")
 

--- a/makemigrations.py
+++ b/makemigrations.py
@@ -35,6 +35,10 @@ settings.configure(
         "retry": 600,
     },
     GID_RANGES=[range(1031386, 1031435)],
+    EMAIL_DIRECTOR_PENDING_PROJECT_REVIEW_EMAIL=False,
+    ALLOCATION_SHORTNAME_MIN_LENGTH=3,
+    ALLOCATION_SHORTNAME_MAX_LENGTH=12,
+    GPFS_API_TIMEOUT=4,
 )
 
 django.setup()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -84,7 +84,7 @@ def pytest_configure():
             if key.isupper()
         }
         | dict(
-            LDAP_ENABLED=False,
+            LDAP_ENABLED=True,
             LDAP_USERNAME="",
             LDAP_PASSWORD="",
             LDAP_URI="",
@@ -307,6 +307,19 @@ def rdf_allocation_dependencies(db):
     AllocationUserStatusChoice.objects.create(name="Active")
 
 
+@pytest.fixture(autouse=True)
+def ldap_connection_mock(mocker):
+    """Mock LDAP connection for tests that require it."""
+    return mocker.patch(
+        "imperial_coldfront_plugin.ldap.Connection",
+        side_effect=RuntimeError(
+            "Un-mocked LDAP connection. If you see this error during a test, it means"
+            "that the test is trying to use the LDAP connection without mocking it. "
+            "Mock the interface to the LDAP module."
+        ),
+    )
+
+
 @pytest.fixture
 def rdf_allocation_shortname(settings):
     """Shortname applied to rdf_allocation fixture."""
@@ -327,7 +340,11 @@ def rdf_allocation_gid(settings):
 
 @pytest.fixture
 def rdf_allocation(
-    project, rdf_allocation_dependencies, rdf_allocation_shortname, rdf_allocation_gid
+    project,
+    rdf_allocation_dependencies,
+    rdf_allocation_shortname,
+    rdf_allocation_gid,
+    mocker,
 ):
     """A Coldfront allocation representing a rdf storage allocation."""
     from coldfront.core.allocation.models import (
@@ -354,11 +371,14 @@ def rdf_allocation(
         allocation=allocation,
         value=rdf_allocation_shortname,
     )
-    AllocationAttribute.objects.create(
-        allocation_attribute_type=gid_attribute_type,
-        allocation=allocation,
-        value=rdf_allocation_gid,
-    )
+    with mocker.patch(
+        "imperial_coldfront_plugin.signals.ldap_gid_in_use", return_value=False
+    ):
+        AllocationAttribute.objects.create(
+            allocation_attribute_type=gid_attribute_type,
+            allocation=allocation,
+            value=rdf_allocation_gid,
+        )
     return allocation
 
 
@@ -371,15 +391,18 @@ def allocation_user_active_status(db):
 
 
 @pytest.fixture
-def allocation_user(allocation_user_active_status, rdf_allocation, user):
+def allocation_user(allocation_user_active_status, rdf_allocation, user, mocker):
     """Provides an active user for rdf_allocation fixture."""
     from coldfront.core.allocation.models import AllocationUser
 
-    return AllocationUser.objects.create(
-        allocation=rdf_allocation,
-        user=user,
-        status=allocation_user_active_status,
-    )
+    with mocker.patch(
+        "imperial_coldfront_plugin.signals.ldap_add_member_to_group",
+    ):
+        return AllocationUser.objects.create(
+            allocation=rdf_allocation,
+            user=user,
+            status=allocation_user_active_status,
+        )
 
 
 @pytest.fixture
@@ -430,12 +453,6 @@ def signals_async_task_mock(mocker):
         return func(*args, **kwargs)
 
     return mocker.patch("imperial_coldfront_plugin.signals.async_task", f)
-
-
-@pytest.fixture
-def enable_ldap(settings):
-    """Fixture to enable LDAP in settings."""
-    settings.LDAP_ENABLED = True
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -313,7 +313,7 @@ def ldap_connection_mock(mocker):
     return mocker.patch(
         "imperial_coldfront_plugin.ldap.Connection",
         side_effect=RuntimeError(
-            "Un-mocked LDAP connection. If you see this error during a test, it means"
+            "Un-mocked LDAP connection. If you see this error during a test, it means "
             "that the test is trying to use the LDAP connection without mocking it. "
             "Mock the interface to the LDAP module."
         ),

--- a/tests/test_signals.py
+++ b/tests/test_signals.py
@@ -7,7 +7,6 @@ from coldfront.core.allocation.models import (
     AllocationUser,
     AllocationUserStatusChoice,
 )
-from coldfront.core.resource.models import Resource, ResourceType
 
 
 @pytest.fixture
@@ -37,208 +36,393 @@ def ldap_gid_in_use_mock(mocker):
 def remove_allocation_group_members_mock(mocker):
     """Mock remove_allocation_group_members task in signals.py."""
     return mocker.patch(
-        "imperial_coldfront_plugin.tasks.remove_allocation_group_members"
+        "imperial_coldfront_plugin.signals.remove_allocation_group_members"
     )
 
 
-def test_sync_ldap_group_membership(
-    ldap_remove_member_mock,
-    ldap_add_member_mock,
-    user,
-    rdf_allocation_ldap_name,
-    allocation_user,
-):
-    """Test sync_ldap_group_membership signal."""
-    # clear mock calls from setup
-    ldap_add_member_mock.reset_mock()
-    ldap_remove_member_mock.assert_not_called()
+class TestAllocationAttributeEnsureNoExistingGID:
+    """Tests for allocation_attribute_ensure_no_existing_gid signal handler."""
 
-    allocation_user_inactive_status = AllocationUserStatusChoice.objects.create(
-        name="Inactive"
-    )
-    allocation_user.status = allocation_user_inactive_status
-    allocation_user.save()
+    @pytest.fixture
+    def gid_attribute_type(self, db):
+        """Fixture to create a GID AllocationAttributeType."""
+        return AllocationAttributeType.objects.get(name="GID")
 
-    ldap_add_member_mock.assert_not_called()
-    ldap_remove_member_mock.assert_called_once_with(
-        rdf_allocation_ldap_name, user.username, allow_missing=True
-    )
+    def test_success(self, rdf_allocation):
+        """Test creating a project with a unique GID succeeds."""
+        # signal is triggered by rdf_allocation fixture creation
 
-
-def test_remove_ldap_group_membership(
-    ldap_remove_member_mock,
-    rdf_allocation_shortname,
-    allocation_user,
-    user,
-    settings,
-):
-    """Test remove_ldap_group_membership signal."""
-    ldap_remove_member_mock.assert_not_called()
-
-    allocation_user.delete()
-
-    ldap_remove_member_mock.assert_called_once_with(
-        f"{settings.LDAP_RDF_SHORTNAME_PREFIX}{rdf_allocation_shortname}",
-        user.username,
-        allow_missing=True,
-    )
-
-
-def test_remove_ldap_group_membership_non_rdf_allocation(
-    ldap_remove_member_mock, allocation_user_active_status, project, user
-):
-    """Test remove_ldap_group_membership_signal for non-rdf allocation."""
-    active_allocation_status, _ = AllocationStatusChoice.objects.get_or_create(
-        name="Active"
-    )
-    allocation = Allocation.objects.create(
-        project=project,
-        status=active_allocation_status,
-    )
-    allocation_user = AllocationUser.objects.create(
-        allocation=allocation,
-        user=user,
-        status=allocation_user_active_status,
-    )
-
-    allocation_user.delete()
-    ldap_remove_member_mock.assert_not_called()
-
-
-def test_ensure_unique_shortname(rdf_allocation, rdf_allocation_shortname):
-    """Test creating a second allocation with the same shortname raises an error."""
-    from coldfront.core.allocation.models import (
-        AllocationAttribute,
-        AllocationAttributeType,
-    )
-
-    shortname_attribute_type = AllocationAttributeType.objects.get(name="Shortname")
-    with pytest.raises(ValueError):
+    def test_ldap_disabled(
+        self, settings, gid_attribute_type, rdf_allocation, ldap_gid_in_use_mock
+    ):
+        """Test that LDAP is not checked when disabled."""
+        settings.LDAP_ENABLED = False
+        ldap_gid_in_use_mock.return_value = True
+        # should not raise an error because LDAP is disabled
         AllocationAttribute.objects.create(
-            allocation_attribute_type=shortname_attribute_type,
+            allocation_attribute_type=gid_attribute_type,
             allocation=rdf_allocation,
+            value=123,
+        )
+
+    def test_existing_gid_database(
+        self, rdf_allocation, rdf_allocation_gid, gid_attribute_type
+    ):
+        """Test creating a project with GID existing in the database raises an error."""
+        with pytest.raises(ValueError):
+            AllocationAttribute.objects.create(
+                allocation_attribute_type=gid_attribute_type,
+                allocation=rdf_allocation,
+                value=rdf_allocation_gid,
+            )
+
+    def test_existing_gid_ldap(
+        self,
+        rdf_allocation,
+        rdf_allocation_gid,
+        ldap_gid_in_use_mock,
+        gid_attribute_type,
+    ):
+        """Test creating a project with an existing GID in LDAP raises an error."""
+        ldap_gid_in_use_mock.return_value = True
+        with pytest.raises(ValueError):
+            AllocationAttribute.objects.create(
+                allocation_attribute_type=gid_attribute_type,
+                allocation=rdf_allocation,
+                value=rdf_allocation_gid,
+            )
+
+
+class TestAllocationAttributeEnsureUniqueShortname:
+    """Tests for allocation_attribute_ensure_unique_shortname signal handler."""
+
+    def test_success(self, rdf_allocation):
+        """Test creating a project with a unique shortname succeeds."""
+        # signal is triggered by rdf_allocation fixture creation
+
+    def test_ensure_unique_shortname(self, rdf_allocation, rdf_allocation_shortname):
+        """Test creating a second allocation with the same shortname raises an error."""
+        shortname_attribute_type = AllocationAttributeType.objects.get(name="Shortname")
+        with pytest.raises(ValueError):
+            AllocationAttribute.objects.create(
+                allocation_attribute_type=shortname_attribute_type,
+                allocation=rdf_allocation,
+                value=rdf_allocation_shortname,
+            )
+        # check there is still only one allocation with the shortname
+        assert AllocationAttribute.objects.get(
+            allocation_attribute_type=shortname_attribute_type,
             value=rdf_allocation_shortname,
         )
-    # check there is still only one allocation with the shortname
-    assert AllocationAttribute.objects.get(
-        allocation_attribute_type=shortname_attribute_type,
-        value=rdf_allocation_shortname,
-    )
 
 
-def test_ensure_unique_group_id(project):
-    """Test creating a second project with the same Group ID raises an error."""
-    from coldfront.core.project.models import (
-        ProjectAttribute,
-        ProjectAttributeType,
-    )
+class TestProjectAttributeEnsureUniqueGroupID:
+    """Tests for project_attribute_ensure_unique_group_id signal handler."""
 
-    group_id_attribute_type = ProjectAttributeType.objects.get(name="Group ID")
-    with pytest.raises(ValueError):
-        ProjectAttribute.objects.create(
+    def test_success(self, project):
+        """Test creating a project with a unique group ID succeeds."""
+        # signal is triggered by project fixture creation
+
+    def test_ensure_unique_group_id(self, project, user):
+        """Test creating a second project with the same Group ID raises an error."""
+        from coldfront.core.project.models import (
+            ProjectAttribute,
+            ProjectAttributeType,
+        )
+
+        group_id_attribute_type = ProjectAttributeType.objects.get(name="Group ID")
+        with pytest.raises(ValueError):
+            ProjectAttribute.objects.create(
+                proj_attr_type=group_id_attribute_type,
+                project=project,
+                value=project.pi.username,
+            )
+        # check there is still only one group id with the value
+        assert ProjectAttribute.objects.get(
             proj_attr_type=group_id_attribute_type,
-            project=project,
             value=project.pi.username,
         )
-    # check there is still only one group id with the shortname
-    assert ProjectAttribute.objects.get(
-        proj_attr_type=group_id_attribute_type,
-        value=project.pi.username,
-    )
 
 
-def test_ensure_no_existing_gid_database(rdf_allocation, rdf_allocation_gid):
-    """Test creating a project with an existing GID in the database raises an error."""
-    gid_attribute_type = AllocationAttributeType.objects.get(name="GID")
-    with pytest.raises(ValueError):
-        AllocationAttribute.objects.create(
-            allocation_attribute_type=gid_attribute_type,
-            allocation=rdf_allocation,
-            value=rdf_allocation_gid,
+@pytest.fixture
+def allocation_active_status(db):
+    """Fixture to create an Active AllocationUserStatusChoice."""
+    return AllocationStatusChoice.objects.get_or_create(name="Active")[0]
+
+
+@pytest.fixture
+def allocation_inactive_status(db):
+    """Fixture to create an Inactive AllocationUserStatusChoice."""
+    return AllocationStatusChoice.objects.get_or_create(name="Inactive")[0]
+
+
+class TestAllocationUserSyncLDAPGroupMembership:
+    """Tests for allocation_user_sync_ldap_group_membership signal handler."""
+
+    @pytest.fixture
+    def allocation_user_inactive_status(self, db):
+        """Fixture to create an Inactive AllocationUserStatusChoice."""
+        return AllocationUserStatusChoice.objects.create(name="Inactive")
+
+    def test_sync_ldap_group_membership_remove(
+        self,
+        ldap_remove_member_mock,
+        ldap_add_member_mock,
+        user,
+        rdf_allocation_ldap_name,
+        rdf_allocation,
+        allocation_user_inactive_status,
+    ):
+        """Test sync_ldap_group_membership signal."""
+        # clear mock calls from setup
+        ldap_add_member_mock.reset_mock()
+        ldap_remove_member_mock.assert_not_called()
+
+        AllocationUser.objects.create(
+            allocation=rdf_allocation, user=user, status=allocation_user_inactive_status
         )
 
-
-def test_ensure_no_existing_gid_ldap(
-    rdf_allocation,
-    rdf_allocation_gid,
-    ldap_gid_in_use_mock,
-):
-    """Test creating a project with an existing GID in LDAP raises an error."""
-    ldap_gid_in_use_mock.return_value = True
-    gid_attribute_type = AllocationAttributeType.objects.get(name="GID")
-    with pytest.raises(ValueError):
-        AllocationAttribute.objects.create(
-            allocation_attribute_type=gid_attribute_type,
-            allocation=rdf_allocation,
-            value=rdf_allocation_gid,
+        ldap_add_member_mock.assert_not_called()
+        ldap_remove_member_mock.assert_called_once_with(
+            rdf_allocation_ldap_name, user.username, allow_missing=True
         )
 
+    def test_sync_ldap_group_membership_add(
+        self,
+        ldap_remove_member_mock,
+        ldap_add_member_mock,
+        user,
+        rdf_allocation_ldap_name,
+        rdf_allocation,
+        allocation_user_active_status,
+    ):
+        """Test sync_ldap_group_membership signal."""
+        ldap_add_member_mock.assert_not_called()
+        ldap_remove_member_mock.assert_not_called()
 
-def test_remove_ldap_group_members_if_allocation_inactive(
-    remove_allocation_group_members_mock,
-    rdf_allocation,
-    allocation_user,
-):
-    """Test remove_ldap_group_members_if_allocation_inactive signal."""
-    remove_allocation_group_members_mock.assert_not_called()
+        AllocationUser.objects.create(
+            allocation=rdf_allocation, user=user, status=allocation_user_active_status
+        )
 
-    # Change allocation status to inactive
-    allocation_inactive_status = AllocationStatusChoice.objects.create(name="Inactive")
-    rdf_allocation.status = allocation_inactive_status
-    rdf_allocation.save()
+        ldap_add_member_mock.assert_called_once_with(
+            rdf_allocation_ldap_name, user.username, allow_already_present=True
+        )
+        ldap_remove_member_mock.assert_not_called()
 
-    remove_allocation_group_members_mock.assert_called_once_with(rdf_allocation.pk)
+    def test_ldap_disabled(
+        self,
+        ldap_remove_member_mock,
+        ldap_add_member_mock,
+        allocation_user,
+        settings,
+        allocation_user_inactive_status,
+    ):
+        """Test that no LDAP operations are performed when LDAP is disabled."""
+        ldap_add_member_mock.assert_not_called()
+        ldap_remove_member_mock.assert_not_called()
+        settings.LDAP_ENABLED = False
+
+        allocation_user.status = allocation_user_inactive_status
+        allocation_user.save()
+
+        ldap_add_member_mock.assert_not_called()
+        ldap_remove_member_mock.assert_not_called()
+
+    def test_non_rdf_allocation(
+        self,
+        ldap_remove_member_mock,
+        ldap_add_member_mock,
+        user,
+        project,
+        allocation_active_status,
+        allocation_user_active_status,
+    ):
+        """Test that signal does not apply to non-RDF allocations."""
+        allocation = Allocation.objects.create(
+            project=project, status=allocation_active_status
+        )
+
+        ldap_add_member_mock.assert_not_called()
+        ldap_remove_member_mock.assert_not_called()
+
+        AllocationUser.objects.create(
+            allocation=allocation,
+            user=user,
+            status=allocation_user_active_status,
+        )
+
+        ldap_add_member_mock.assert_not_called()
+        ldap_remove_member_mock.assert_not_called()
+
+    def test_inactive_allocation(
+        self,
+        ldap_remove_member_mock,
+        ldap_add_member_mock,
+        user,
+        rdf_allocation,
+        allocation_inactive_status,
+        allocation_user_active_status,
+    ):
+        """Test that no LDAP operations are performed for inactive allocations."""
+        rdf_allocation.status = allocation_inactive_status
+        rdf_allocation.save()
+
+        ldap_add_member_mock.assert_not_called()
+        ldap_remove_member_mock.assert_not_called()
+
+        AllocationUser.objects.create(
+            allocation=rdf_allocation,
+            user=user,
+            status=allocation_user_active_status,
+        )
+
+        ldap_add_member_mock.assert_not_called()
+        ldap_remove_member_mock.assert_not_called()
 
 
-def test_remove_ldap_group_members_if_allocation_active(
-    remove_allocation_group_members_mock,
-    rdf_allocation,
-    allocation_user,
-):
-    """Test that task is not called when allocation is active."""
-    remove_allocation_group_members_mock.assert_not_called()
+class TestAllocationUserLDAPGroupRemoveMembership:
+    """Tests for allocation_user_ldap_group_membership_deletion signal handler."""
 
-    # Allocation is already active, so saving shouldn't trigger the task
-    rdf_allocation.save()
+    def test_success(
+        self,
+        ldap_remove_member_mock,
+        rdf_allocation_shortname,
+        allocation_user,
+        user,
+        settings,
+    ):
+        """Test remove_ldap_group_membership signal."""
+        ldap_remove_member_mock.assert_not_called()
 
-    remove_allocation_group_members_mock.assert_not_called()
+        allocation_user.delete()
+
+        ldap_remove_member_mock.assert_called_once_with(
+            f"{settings.LDAP_RDF_SHORTNAME_PREFIX}{rdf_allocation_shortname}",
+            user.username,
+            allow_missing=True,
+        )
+
+    def test_ldap_disabled(
+        self,
+        ldap_remove_member_mock,
+        allocation_user,
+        settings,
+    ):
+        """Test that no LDAP operations are performed when LDAP is disabled."""
+        ldap_remove_member_mock.assert_not_called()
+        settings.LDAP_ENABLED = False
+
+        allocation_user.delete()
+
+        ldap_remove_member_mock.assert_not_called()
+
+    def test_non_rdf_allocation(
+        self,
+        ldap_remove_member_mock,
+        allocation_active_status,
+        allocation_user_active_status,
+        project,
+        user,
+    ):
+        """Test remove_ldap_group_membership_signal for non-rdf allocation."""
+        allocation = Allocation.objects.create(
+            project=project,
+            status=allocation_active_status,
+        )
+        allocation_user = AllocationUser.objects.create(
+            allocation=allocation,
+            user=user,
+            status=allocation_user_active_status,
+        )
+
+        allocation_user.delete()
+        ldap_remove_member_mock.assert_not_called()
+
+    def test_inactive_allocation(
+        self,
+        remove_allocation_group_members_mock,
+        ldap_remove_member_mock,
+        allocation_user,
+        allocation_inactive_status,
+    ):
+        """Test that no LDAP operations are performed for inactive allocations."""
+        allocation_user.allocation.status = allocation_inactive_status
+        allocation_user.allocation.save()
+
+        allocation_user.delete()
+
+        ldap_remove_member_mock.assert_not_called()
 
 
-def test_remove_ldap_group_members_non_rdf_allocation(
-    remove_allocation_group_members_mock,
-    project,
-    user,
-    allocation_user_active_status,
-):
-    """Test that task is not called for non rdf allocations."""
-    allocation_inactive_status = AllocationStatusChoice.objects.create(name="Inactive")
-    active_allocation_status, _ = AllocationStatusChoice.objects.get_or_create(
-        name="Active"
-    )
-    allocation = Allocation.objects.create(
-        project=project,
-        status=active_allocation_status,
-    )
-    AllocationUser.objects.create(
-        allocation=allocation,
-        user=user,
-        status=allocation_user_active_status,
-    )
-    allocation.status = allocation_inactive_status
-    allocation.save()
-    remove_allocation_group_members_mock.assert_not_called()
+class TestAllocationRemoveLDAPGroupMembersIfInactive:
+    """Tests for allocation_remove_ldap_group_members_if_inactive signal handler."""
 
+    def test_success(
+        self,
+        remove_allocation_group_members_mock,
+        rdf_allocation,
+        allocation_inactive_status,
+        allocation_user,
+    ):
+        """Test remove_ldap_group_members_if_allocation_inactive signal."""
+        remove_allocation_group_members_mock.assert_not_called()
 
-def test_remove_ldap_group_members_ldap_disabled(
-    remove_allocation_group_members_mock, rdf_allocation, settings
-):
-    """Test that task is not called when LDAP is disabled."""
-    settings.LDAP_ENABLED = False
-    allocation_inactive_status = AllocationStatusChoice.objects.create(name="Inactive")
-    rdf_allocation.status = allocation_inactive_status
-    rdf_allocation.save()
+        # Change allocation status to inactive
+        rdf_allocation.status = allocation_inactive_status
+        rdf_allocation.save()
 
-    remove_allocation_group_members_mock.assert_not_called()
+        remove_allocation_group_members_mock.assert_called_once_with(rdf_allocation.pk)
+
+    def test_status_active(
+        self,
+        remove_allocation_group_members_mock,
+        rdf_allocation,
+        allocation_user,
+    ):
+        """Test that task is not called when allocation is active."""
+        remove_allocation_group_members_mock.assert_not_called()
+
+        # Allocation is already active, so saving shouldn't trigger the task
+        rdf_allocation.save()
+
+        remove_allocation_group_members_mock.assert_not_called()
+
+    def test_non_rdf_allocation(
+        self,
+        remove_allocation_group_members_mock,
+        project,
+        user,
+        allocation_user_active_status,
+        allocation_active_status,
+        allocation_inactive_status,
+    ):
+        """Test that task is not called for non rdf allocations."""
+        allocation = Allocation.objects.create(
+            project=project,
+            status=allocation_active_status,
+        )
+        AllocationUser.objects.create(
+            allocation=allocation,
+            user=user,
+            status=allocation_user_active_status,
+        )
+        allocation.status = allocation_inactive_status
+        allocation.save()
+        remove_allocation_group_members_mock.assert_not_called()
+
+    def test_ldap_disabled(
+        self,
+        remove_allocation_group_members_mock,
+        rdf_allocation,
+        allocation_inactive_status,
+        settings,
+    ):
+        """Test that task is not called when LDAP is disabled."""
+        settings.LDAP_ENABLED = False
+        rdf_allocation.status = allocation_inactive_status
+        rdf_allocation.save()
+
+        remove_allocation_group_members_mock.assert_not_called()
 
 
 @pytest.fixture
@@ -247,94 +431,65 @@ def zero_quota_mock(mocker):
     return mocker.patch("imperial_coldfront_plugin.tasks.zero_allocation_gpfs_quota")
 
 
-def test_allocation_expired_handler_triggers_task(rdf_allocation, zero_quota_mock):
-    """Test that changing allocation status to Expired spawns the quota zeroing task."""
-    expired_status = AllocationStatusChoice.objects.create(name="Expired")
-    rdf_allocation.status = expired_status
-    rdf_allocation.save()
-    zero_quota_mock.assert_called_once_with(rdf_allocation.pk)
+class TestAllocationExpiryZeroQuota:
+    """Tests for allocation_expiry_zero_quota signal handler."""
 
+    @pytest.fixture
+    def expired_status(self, db):
+        """Fixture to create an Expired AllocationStatusChoice."""
+        return AllocationStatusChoice.objects.create(name="Expired")
 
-def test_allocation_expired_handler_does_not_trigger_for_other_statuses(
-    rdf_allocation, rdf_allocation_gid, zero_quota_mock
-):
-    """Test that changing to a non-Expired status does not trigger the task."""
-    removed_status = AllocationStatusChoice.objects.create(name="Removed")
-    rdf_allocation.status = removed_status
-    rdf_allocation.save()
-    zero_quota_mock.assert_not_called()
+    @pytest.fixture
+    def removed_status(self, db):
+        """Fixture to create a Removed AllocationStatusChoice."""
+        return AllocationStatusChoice.objects.create(name="Removed")
 
+    def test_success(self, rdf_allocation, zero_quota_mock, expired_status):
+        """Test that changing allocation status to Expired spawns quota zeroing task."""
+        rdf_allocation.status = expired_status
+        rdf_allocation.save()
+        zero_quota_mock.assert_called_once_with(rdf_allocation.pk)
 
-def test_allocation_expired_handler_skips_new_allocations(
-    project,
-    remove_allocation_group_members_mock,
-):
-    """Test that creating a new allocation does not trigger the task (pk is None)."""
-    expired_status = AllocationStatusChoice.objects.create(name="Expired")
-    rdf_resource = Resource.objects.filter(name__icontains="RDF").first()
+    def test_does_not_trigger_for_other_statuses(
+        self, rdf_allocation, rdf_allocation_gid, zero_quota_mock, removed_status
+    ):
+        """Test that changing to a non-Expired status does not trigger the task."""
+        rdf_allocation.status = removed_status
+        rdf_allocation.save()
+        zero_quota_mock.assert_not_called()
 
-    allocation = Allocation(
-        project=project,
-        status=expired_status,
-    )
-    allocation.save()
-    if rdf_resource:
-        allocation.resources.add(rdf_resource)
+    def test_skips_new_allocations(
+        self,
+        project,
+        remove_allocation_group_members_mock,
+        expired_status,
+    ):
+        """Test that creating new allocation does not trigger the task (pk is None)."""
+        Allocation.objects.create(project=project, status=expired_status)
+        remove_allocation_group_members_mock.assert_not_called()
 
-    remove_allocation_group_members_mock.assert_not_called()
+    def test_non_rdf_allocation(
+        self, project, zero_quota_mock, allocation_active_status, expired_status
+    ):
+        """Test that expiring a non-rdf allocation does not trigger the task."""
+        allocation = Allocation.objects.create(
+            project=project, status=allocation_active_status
+        )
+        allocation.status = expired_status
+        allocation.save()
+        zero_quota_mock.assert_not_called()
 
+    def test_only_trigger_on_status_change_from_active_to_expired(
+        self, rdf_allocation, zero_quota_mock, expired_status, removed_status
+    ):
+        """Test only triggered when changing from Active to Expired statuses."""
+        # changing to removed status doesn't trigger the task
+        rdf_allocation.status = removed_status
+        rdf_allocation.save()
+        zero_quota_mock.assert_not_called()
 
-def test_allocation_expired_handler_skips_non_rdf_active_allocation(
-    project, zero_quota_mock
-):
-    """Test that expiring an allocation without the 'RDF Active' resource does not trigger the task."""  # noqa E501
-    active_status, _ = AllocationStatusChoice.objects.get_or_create(name="Active")
-    expired_status, _ = AllocationStatusChoice.objects.get_or_create(name="Expired")
-
-    resource_type = ResourceType.objects.first()
-    other_resource = Resource.objects.create(
-        name="Other Storage",
-        resource_type=resource_type,
-    )
-
-    allocation = Allocation.objects.create(project=project, status=active_status)
-    allocation.resources.add(other_resource)
-
-    allocation.status = expired_status
-    allocation.save()
-
-    zero_quota_mock.assert_not_called()
-
-
-def test_sync_ldap_group_membership_non_rdf_allocation(
-    ldap_remove_member_mock,
-    ldap_add_member_mock,
-    user,
-    allocation_user_active_status,
-    project,
-):
-    """Test sync_ldap_group_membership signal does not apply to non-RDF allocations."""
-    active_allocation_status, _ = AllocationStatusChoice.objects.get_or_create(
-        name="Active"
-    )
-    allocation_user_inactive_status = AllocationUserStatusChoice.objects.create(
-        name="Inactive"
-    )
-    allocation = Allocation.objects.create(
-        project=project,
-        status=active_allocation_status,
-    )
-    allocation_user = AllocationUser.objects.create(
-        allocation=allocation,
-        user=user,
-        status=allocation_user_active_status,
-    )
-
-    ldap_add_member_mock.assert_not_called()
-    ldap_remove_member_mock.assert_not_called()
-
-    allocation_user.status = allocation_user_inactive_status
-    allocation_user.save()
-
-    ldap_add_member_mock.assert_not_called()
-    ldap_remove_member_mock.assert_not_called()
+        # changing from removed to expired doesn't trigger the task either
+        zero_quota_mock.reset_mock()
+        rdf_allocation.status = expired_status
+        rdf_allocation.save()
+        zero_quota_mock.assert_not_called()

--- a/tests/test_signals.py
+++ b/tests/test_signals.py
@@ -47,10 +47,10 @@ def test_sync_ldap_group_membership(
     user,
     rdf_allocation_ldap_name,
     allocation_user,
-    enable_ldap,
 ):
     """Test sync_ldap_group_membership signal."""
-    ldap_add_member_mock.assert_not_called()
+    # clear mock calls from setup
+    ldap_add_member_mock.reset_mock()
     ldap_remove_member_mock.assert_not_called()
 
     allocation_user_inactive_status = AllocationUserStatusChoice.objects.create(
@@ -65,37 +65,11 @@ def test_sync_ldap_group_membership(
     )
 
 
-def test_sync_ldap_group_membership_no_project_id(
-    ldap_remove_member_mock,
-    ldap_add_member_mock,
-    user,
-    rdf_allocation,
-    rdf_allocation_shortname,
-    allocation_user_active_status,
-):
-    """Test sync_ldap_group_membership signal for non-rdf allocations."""
-    rdf_allocation.shortname_attr.delete()
-    allocation_user = AllocationUser.objects.create(
-        allocation=rdf_allocation,
-        user=user,
-        status=allocation_user_active_status,
-    )
-
-    ldap_add_member_mock.assert_not_called()
-    ldap_remove_member_mock.assert_not_called()
-
-    allocation_user.delete()
-
-    ldap_add_member_mock.assert_not_called()
-    ldap_remove_member_mock.assert_not_called()
-
-
 def test_remove_ldap_group_membership(
     ldap_remove_member_mock,
     rdf_allocation_shortname,
     allocation_user,
     user,
-    enable_ldap,
     settings,
 ):
     """Test remove_ldap_group_membership signal."""
@@ -111,7 +85,7 @@ def test_remove_ldap_group_membership(
 
 
 def test_remove_ldap_group_membership_non_rdf_allocation(
-    ldap_remove_member_mock, allocation_user_active_status, project, user, enable_ldap
+    ldap_remove_member_mock, allocation_user_active_status, project, user
 ):
     """Test remove_ldap_group_membership_signal for non-rdf allocation."""
     active_allocation_status, _ = AllocationStatusChoice.objects.get_or_create(
@@ -204,7 +178,6 @@ def test_remove_ldap_group_members_if_allocation_inactive(
     remove_allocation_group_members_mock,
     rdf_allocation,
     allocation_user,
-    enable_ldap,
 ):
     """Test remove_ldap_group_members_if_allocation_inactive signal."""
     remove_allocation_group_members_mock.assert_not_called()
@@ -221,7 +194,6 @@ def test_remove_ldap_group_members_if_allocation_active(
     remove_allocation_group_members_mock,
     rdf_allocation,
     allocation_user,
-    enable_ldap,
 ):
     """Test that task is not called when allocation is active."""
     remove_allocation_group_members_mock.assert_not_called()
@@ -237,7 +209,6 @@ def test_remove_ldap_group_members_non_rdf_allocation(
     project,
     user,
     allocation_user_active_status,
-    enable_ldap,
 ):
     """Test that task is not called for non rdf allocations."""
     allocation_inactive_status = AllocationStatusChoice.objects.create(name="Inactive")
@@ -259,10 +230,10 @@ def test_remove_ldap_group_members_non_rdf_allocation(
 
 
 def test_remove_ldap_group_members_ldap_disabled(
-    remove_allocation_group_members_mock,
-    rdf_allocation,
+    remove_allocation_group_members_mock, rdf_allocation, settings
 ):
     """Test that task is not called when LDAP is disabled."""
+    settings.LDAP_ENABLED = False
     allocation_inactive_status = AllocationStatusChoice.objects.create(name="Inactive")
     rdf_allocation.status = allocation_inactive_status
     rdf_allocation.save()
@@ -271,43 +242,32 @@ def test_remove_ldap_group_members_ldap_disabled(
 
 
 @pytest.fixture
-def async_task_mock(mocker):
-    """Mock async_task from django_q.tasks."""
-    mock = mocker.patch("imperial_coldfront_plugin.signals.async_task")
-    mock.assert_not_called()
-    return mock
+def zero_quota_mock(mocker):
+    """Mock zero_allocation_gpfs_quota task."""
+    return mocker.patch("imperial_coldfront_plugin.tasks.zero_allocation_gpfs_quota")
 
 
-def test_allocation_expired_handler_triggers_task(
-    async_task_mock,
-    rdf_allocation,
-):
+def test_allocation_expired_handler_triggers_task(rdf_allocation, zero_quota_mock):
     """Test that changing allocation status to Expired spawns the quota zeroing task."""
     expired_status = AllocationStatusChoice.objects.create(name="Expired")
     rdf_allocation.status = expired_status
     rdf_allocation.save()
-
-    async_task_mock.assert_called_once_with(
-        "imperial_coldfront_plugin.tasks.zero_allocation_gpfs_quota",
-        rdf_allocation.pk,
-    )
+    zero_quota_mock.assert_called_once_with(rdf_allocation.pk)
 
 
 def test_allocation_expired_handler_does_not_trigger_for_other_statuses(
-    async_task_mock,
-    rdf_allocation,
+    rdf_allocation, rdf_allocation_gid, zero_quota_mock
 ):
     """Test that changing to a non-Expired status does not trigger the task."""
     removed_status = AllocationStatusChoice.objects.create(name="Removed")
     rdf_allocation.status = removed_status
     rdf_allocation.save()
-
-    async_task_mock.assert_not_called()
+    zero_quota_mock.assert_not_called()
 
 
 def test_allocation_expired_handler_skips_new_allocations(
-    async_task_mock,
     project,
+    remove_allocation_group_members_mock,
 ):
     """Test that creating a new allocation does not trigger the task (pk is None)."""
     expired_status = AllocationStatusChoice.objects.create(name="Expired")
@@ -321,12 +281,11 @@ def test_allocation_expired_handler_skips_new_allocations(
     if rdf_resource:
         allocation.resources.add(rdf_resource)
 
-    async_task_mock.assert_not_called()
+    remove_allocation_group_members_mock.assert_not_called()
 
 
 def test_allocation_expired_handler_skips_non_rdf_active_allocation(
-    async_task_mock,
-    project,
+    project, zero_quota_mock
 ):
     """Test that expiring an allocation without the 'RDF Active' resource does not trigger the task."""  # noqa E501
     active_status, _ = AllocationStatusChoice.objects.get_or_create(name="Active")
@@ -344,7 +303,7 @@ def test_allocation_expired_handler_skips_non_rdf_active_allocation(
     allocation.status = expired_status
     allocation.save()
 
-    async_task_mock.assert_not_called()
+    zero_quota_mock.assert_not_called()
 
 
 def test_sync_ldap_group_membership_non_rdf_allocation(
@@ -352,7 +311,6 @@ def test_sync_ldap_group_membership_non_rdf_allocation(
     ldap_add_member_mock,
     user,
     allocation_user_active_status,
-    enable_ldap,
     project,
 ):
     """Test sync_ldap_group_membership signal does not apply to non-RDF allocations."""

--- a/tests/test_signals.py
+++ b/tests/test_signals.py
@@ -146,13 +146,13 @@ class TestProjectAttributeEnsureUniqueGroupID:
 
 @pytest.fixture
 def allocation_active_status(db):
-    """Fixture to create an Active AllocationUserStatusChoice."""
+    """Fixture to create an Active AllocationStatusChoice."""
     return AllocationStatusChoice.objects.get_or_create(name="Active")[0]
 
 
 @pytest.fixture
 def allocation_inactive_status(db):
-    """Fixture to create an Inactive AllocationUserStatusChoice."""
+    """Fixture to create an Inactive AllocationStatusChoice."""
     return AllocationStatusChoice.objects.get_or_create(name="Inactive")[0]
 
 
@@ -461,12 +461,12 @@ class TestAllocationExpiryZeroQuota:
     def test_skips_new_allocations(
         self,
         project,
-        remove_allocation_group_members_mock,
+        zero_quota_mock,
         expired_status,
     ):
         """Test that creating new allocation does not trigger the task (pk is None)."""
         Allocation.objects.create(project=project, status=expired_status)
-        remove_allocation_group_members_mock.assert_not_called()
+        zero_quota_mock.assert_not_called()
 
     def test_non_rdf_allocation(
         self, project, zero_quota_mock, allocation_active_status, expired_status

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -158,7 +158,6 @@ def test_create_rdf_allocation(
     rdf_allocation_ldap_name,
     settings,
     rdf_form_data,
-    enable_ldap,
 ):
     """Test create_rdf_allocation task."""
     # set all of these so they are not empty
@@ -254,7 +253,6 @@ def test_create_rdf_allocation_ldap_rollback(
     rdf_allocation_ldap_name,
     settings,
     rdf_form_data,
-    enable_ldap,
 ):
     """Test create_rdf_allocation task rolls back on LDAP error."""
     # first ldap call now raises an error
@@ -280,7 +278,6 @@ def test_create_rdf_allocation_gpfs_rollback(
     rdf_allocation_ldap_name,
     settings,
     rdf_form_data,
-    enable_ldap,
 ):
     """Test create_rdf_allocation task rolls back on GPFS error."""
     # first gpfs call now raises an error
@@ -336,7 +333,6 @@ def test_check_ldap_consistency_missing_members(
     ldap_group_search_mock,
     notify_mock,
     rdf_allocation_ldap_name,
-    enable_ldap,
 ):
     """Test when a user is missing from AD group."""
     username = allocation_user.user.username
@@ -361,7 +357,6 @@ def test_check_ldap_consistency_extra_members(
     ldap_group_search_mock,
     notify_mock,
     rdf_allocation_ldap_name,
-    enable_ldap,
 ):
     """Test when there are extra users in AD group."""
     username = allocation_user.user.username
@@ -400,7 +395,6 @@ def test_remove_allocation_group_members(
     rdf_allocation,
     allocation_user,
     rdf_allocation_ldap_name,
-    enable_ldap,
 ):
     """Test _remove_allocation_group_members removes all active users."""
     from imperial_coldfront_plugin.tasks import remove_allocation_group_members
@@ -423,7 +417,6 @@ def test_remove_allocation_group_members_multiple_users(
     allocation_user_active_status,
     user_factory,
     rdf_allocation_ldap_name,
-    enable_ldap,
 ):
     """Test _remove_allocation_group_members removes multiple active users."""
     from imperial_coldfront_plugin.tasks import remove_allocation_group_members
@@ -492,7 +485,6 @@ def test_update_allocation_status_feature_flag(settings, rdf_allocation):
 )
 def test_update_allocation_status(
     rdf_allocation,
-    enable_ldap,
     days_offset,
     expected_status_name,
 ):


### PR DESCRIPTION
# Description


- Change the value of `LDAP_ENABLED` to default to True for all tests. This previously had to be done on a test-by-test basis and was missing in some cases leading to some signal tests terminating early.
- Put in place a global `ldap_connection_mock` that catches any time a test tries to create a connection object. This brings LDAP testing in line with the how we do HTTP tests. It is used to make sure that mocks to ldap methods are being used as required in tests.
- Rationalise imports and fixtures in signal tests.
- Rename signals to be more descriptive about which model they apply to.
- Group together related tests into classes.
- Added some missing tests signal functionality.

Fixes # (issue)

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [ ] All tests pass (eg. `python -m pytest`)
- [ ] The documentation builds and looks OK (eg. `python -m sphinx -b html docs docs/build`)
- [ ] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
