### PR TITLE
Add user_create_hx2_allocation view

### DIFF
--- a/imperial_coldfront_plugin/forms.py
+++ b/imperial_coldfront_plugin/forms.py
@@ -374,3 +374,17 @@ class CreditTransactionForm(forms.ModelForm["CreditTransaction"]):
         widget=forms.Textarea(attrs={"rows": 3}),
         help_text="Description of the transaction",
     )
+
+
+class HX2TermsAndConditionsForm(forms.Form):
+    """Form for accepting terms and conditions."""
+
+    project = forms.ModelChoiceField(
+        queryset=ICLProject.objects.none(),
+        widget=_js_select_widget(),
+        label="Please select which group you would like to grant access to.",
+    )
+    accept_terms = forms.BooleanField(
+        required=True,
+        label="I have read and accept the terms and conditions.",
+    )

--- a/imperial_coldfront_plugin/models.py
+++ b/imperial_coldfront_plugin/models.py
@@ -157,7 +157,7 @@ class HX2AllocationManager(models.Manager["HX2Allocation"]):
         status: AllocationStatusChoice,
         quantity: int,
         start_date: date,
-        end_date: date,
+        end_date: date | None,
         justification: str,
         description: str,
         is_locked: bool,

--- a/imperial_coldfront_plugin/templates/imperial_coldfront_plugin/existing_hx2_allocation.html
+++ b/imperial_coldfront_plugin/templates/imperial_coldfront_plugin/existing_hx2_allocation.html
@@ -1,0 +1,13 @@
+{% extends "common/base.html" %}
+{% block content %}
+  <div class="container mt-4">
+    <div class="card">
+      <div class="card-header">
+        <h2>Unable to request HX2 Access</h2>
+      </div>
+      <div class="card-body">
+        <p>Your account already has a group with an active allocation for HX2.</p>
+      </div>
+    </div>
+  </div>
+{% endblock content %}

--- a/imperial_coldfront_plugin/templates/imperial_coldfront_plugin/hx2_allocation_self_creation.html
+++ b/imperial_coldfront_plugin/templates/imperial_coldfront_plugin/hx2_allocation_self_creation.html
@@ -1,0 +1,20 @@
+{% extends "common/base.html" %}
+{% load crispy_forms_tags %}
+{% block content %}
+  <div class="container mt-4">
+    <div class="card">
+      <div class="card-header">
+        <h2>HX2 Access Terms and Conditions</h2>
+      </div>
+      <div class="card-body">
+        <p>You must agree to...</p>
+        <form method="post">
+          {% csrf_token %} {{ form|crispy }}
+          <div class="mt-4">
+            <button type="submit" class="btn btn-primary">Create</button>
+          </div>
+        </form>
+      </div>
+    </div>
+  </div>
+{% endblock content %}

--- a/imperial_coldfront_plugin/urls.py
+++ b/imperial_coldfront_plugin/urls.py
@@ -44,4 +44,9 @@ urlpatterns = [
         views.project_credit_transactions,
         name="project-credit-transactions",
     ),
+    path(
+        "user_create_hx2_allocation/",
+        views.user_create_hx2_allocation,
+        name="user_create_hx2_allocation",
+    ),
 ]

--- a/imperial_coldfront_plugin/views.py
+++ b/imperial_coldfront_plugin/views.py
@@ -455,7 +455,7 @@ def user_create_hx2_allocation(request: "AuthenticatedHttpRequest") -> HttpRespo
             quantity=1,
             start_date=timezone.now().date(),
             end_date=None,
-            justification="User self-allocated Hx2 allocation",
+            justification="User self-allocated HX2 allocation",
             description="Provides access to HX2 for all allocation users.",
             is_locked=False,
             is_changeable=True,

--- a/imperial_coldfront_plugin/views.py
+++ b/imperial_coldfront_plugin/views.py
@@ -3,7 +3,7 @@
 import re
 from typing import TYPE_CHECKING
 
-from coldfront.core.allocation.models import Allocation
+from coldfront.core.allocation.models import Allocation, AllocationStatusChoice
 from coldfront.core.project.forms import ProjectAddUserForm
 from coldfront.core.project.models import (
     Project,
@@ -17,10 +17,11 @@ from coldfront.core.user.utils import CombinedUserSearch, UserSearch
 from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.contrib.auth.decorators import login_required
-from django.forms import formset_factory
+from django.forms import ModelChoiceField, formset_factory
 from django.http import HttpRequest, HttpResponse, HttpResponseForbidden
 from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import reverse
+from django.utils import timezone
 from django_q.tasks import async_task, fetch
 
 from .dart import create_dart_id_attribute
@@ -28,13 +29,14 @@ from .forms import (
     AdminProjectCreationForm,
     CreditTransactionForm,
     DartIDForm,
+    HX2TermsAndConditionsForm,
     ProjectAddUsersToAllocationShortnameForm,
     RDFAllocationForm,
     UserProjectCreationForm,
     get_department_choices,
 )
 from .microsoft_graph_client import get_graph_api_client
-from .models import CreditTransaction, ICLProject
+from .models import CreditTransaction, HX2Allocation, ICLProject
 from .policy import (
     check_project_pi_or_superuser,
     user_eligible_for_hpc_access,
@@ -415,4 +417,49 @@ def project_credit_transactions(
             "rows": rows,
             "total_balance": running,
         },
+    )
+
+
+@login_required
+def user_create_hx2_allocation(request: "AuthenticatedHttpRequest") -> HttpResponse:
+    """Create an HX2 allocation for the user."""
+    if Allocation.objects.filter(
+        project__pi=request.user,
+        status__name="Active",
+        resources__name="HX2",
+    ).exists():
+        # render info page saying user already has an active HX2 allocation
+        return render(request, "imperial_coldfront_plugin/existing_hx2_allocation.html")
+
+    form = HX2TermsAndConditionsForm(request.POST or None)
+
+    # set the project choices queryset to only the projects of the user
+    # this limits the selection to only the user's projects
+    # it is also used in form validation to ensure the user can only create
+    # allocations for their own projects
+    projects = Project.objects.filter(pi=request.user, status__name="Active")
+    project_field = form.fields["project"]
+    if not isinstance(project_field, ModelChoiceField):
+        # this keeps mypy happy as otherwise it won't allow setting the queryset on the
+        # field as it doesn't know which Field subclass it is.
+        raise TypeError("Expected 'project' field to be a ModelChoiceField.")
+    project_field.queryset = projects
+
+    if form.is_valid():
+        allocation = HX2Allocation.objects.create_hx2allocation(
+            project=form.cleaned_data["project"],
+            status=AllocationStatusChoice.objects.get(name="Active"),
+            quantity=1,
+            start_date=timezone.now().date(),
+            end_date=None,
+            justification="User self-allocated Hx2 allocation",
+            description="Provides access to HX2 for all allocation users.",
+            is_locked=False,
+            is_changeable=True,
+        )
+        return redirect(reverse("allocation-detail", args=[allocation.pk]))
+    return render(
+        request,
+        "imperial_coldfront_plugin/hx2_allocation_self_creation.html",
+        context=dict(form=form),
     )

--- a/imperial_coldfront_plugin/views.py
+++ b/imperial_coldfront_plugin/views.py
@@ -423,6 +423,9 @@ def project_credit_transactions(
 @login_required
 def user_create_hx2_allocation(request: "AuthenticatedHttpRequest") -> HttpResponse:
     """Create an HX2 allocation for the user."""
+    if not settings.ENABLE_USER_GROUP_CREATION:
+        return HttpResponseForbidden()
+
     if Allocation.objects.filter(
         project__pi=request.user,
         status__name="Active",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -245,31 +245,58 @@ def user_or_superuser(request):
 
 
 @pytest.fixture
-def project(user):
-    """Provides a Coldfront project owned by a user."""
+def project_active_status(db):
+    """Create a ProjectStatusChoice with name='Active'."""
+    from coldfront.core.project.models import ProjectStatusChoice
+
+    return ProjectStatusChoice.objects.get_or_create(name="Active")[0]
+
+
+@pytest.fixture
+def field_of_science_other(db):
+    """Create a FieldOfScience with description='Other'."""
     from coldfront.core.field_of_science.models import FieldOfScience
+
+    return FieldOfScience.objects.get_or_create(description="Other")[0]
+
+
+@pytest.fixture
+def project_factory(project_active_status, field_of_science_other):
+    """Provides a factory for Coldfront projects.
+
+    The factory takes the following arguments:
+
+    - user: The owner of the project. Default is `user` fixture.
+    """
+
+    def create_project(pi, title):
+        from imperial_coldfront_plugin.models import ICLProject
+
+        return ICLProject.objects.create(
+            pi=pi,
+            title=title,
+            status=project_active_status,
+            field_of_science=field_of_science_other,
+        )
+
+    return create_project
+
+
+@pytest.fixture
+def project(user, project_factory):
+    """Provides a Coldfront project owned by a user."""
     from coldfront.core.project.models import (
         ProjectAttribute,
         ProjectAttributeType,
-        ProjectStatusChoice,
         ProjectUser,
         ProjectUserRoleChoice,
         ProjectUserStatusChoice,
     )
 
-    from imperial_coldfront_plugin.models import ICLProject
-
-    project_active_status = ProjectStatusChoice.objects.create(name="Active")
-    field_of_science_other = FieldOfScience.objects.create(description="Other")
     project_user_active_status = ProjectUserStatusChoice.objects.create(name="Active")
     project_user_role_manager = ProjectUserRoleChoice.objects.create(name="Manager")
 
-    project = ICLProject.objects.create(
-        pi=user,
-        title=f"{user.get_full_name()}'s Research Group",
-        status=project_active_status,
-        field_of_science=field_of_science_other,
-    )
+    project = project_factory(pi=user, title=f"{user.get_full_name()}'s Research Group")
     department_attribute_type = ProjectAttributeType.objects.get(name="Department")
     faculty_attribute_type = ProjectAttributeType.objects.get(name="Faculty")
     group_id_attribute_type = ProjectAttributeType.objects.get(name="Group ID")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -266,7 +266,8 @@ def project_factory(project_active_status, field_of_science_other):
 
     The factory takes the following arguments:
 
-    - user: The owner of the project. Default is `user` fixture.
+    - pi: The owner of the project.
+    - title: The title of the project.
     """
 
     def create_project(pi, title):

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1232,3 +1232,10 @@ class TestUserCreateHX2AllocationView(LoginRequiredMixin):
         form = response.context["form"]
         assert form.fields["project"].queryset.get() == project
         assert not form.fields["accept_terms"].initial
+
+    def test_feature_flag(self, auth_client_factory, project, user_factory, settings):
+        """Test that the view is disabled when the feature flag is off."""
+        settings.ENABLE_USER_GROUP_CREATION = False
+        client = auth_client_factory(project.pi)
+        response = client.get(self._get_url())
+        assert response.status_code == 403

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -6,7 +6,7 @@ from unittest.mock import patch
 
 import pytest
 from bs4 import BeautifulSoup
-from coldfront.core.allocation.models import AllocationStatusChoice
+from coldfront.core.allocation.models import Allocation, AllocationStatusChoice
 from coldfront.core.project.models import ProjectStatusChoice
 from django.conf import settings
 from django.shortcuts import render
@@ -49,6 +49,12 @@ def get_graph_api_client_mock(mocker, parsed_profile):
     mock().user_profile.return_value = parsed_profile
     mock().user_search_by.return_value = [parsed_profile]
     return mock
+
+
+@pytest.fixture
+def allocation_active_status():
+    """Fixture for an active allocation status choice."""
+    return AllocationStatusChoice.objects.create(name="Active")
 
 
 class TestHomeView:
@@ -1164,3 +1170,65 @@ class TestAllocationDetailBanners:
         assert not soup.find("div", id="deleted-allocation")
         assert not soup.find("div", id="removed-allocation")
         assert not soup.find("div", id="archived-allocation")
+
+
+class TestUserCreateHX2AllocationView(LoginRequiredMixin):
+    """Tests for the user_create_hx2_allocation view."""
+
+    def _get_url(self):
+        return reverse("imperial_coldfront_plugin:user_create_hx2_allocation")
+
+    def test_existing_allocation(self, auth_client_factory, hx2_allocation, project):
+        """Test that users with an existing allocation cannot create another."""
+        client = auth_client_factory(hx2_allocation.project.pi)
+        response = client.get(self._get_url())
+        assert response.status_code == 200
+        assert b"Unable to request HX2 Access" in response.content
+
+    @patch("imperial_coldfront_plugin.signals.ldap_gid_in_use", return_value=False)
+    @patch("imperial_coldfront_plugin.models.ldap_create_group")
+    def test_post(
+        self,
+        ldap_create_group_mock,
+        ldap_gid_in_use_mock,
+        auth_client_factory,
+        project,
+        rdf_allocation_dependencies,
+    ):
+        """Test that a user can create an HX2 allocation."""
+        client = auth_client_factory(project.pi)
+        response = client.post(
+            self._get_url(), data=dict(project=project.pk, accept_terms=True)
+        )
+        allocation = Allocation.objects.get(project=project, resources__name="HX2")
+        assertRedirects(
+            response,
+            reverse("allocation-detail", kwargs=dict(allocation_pk=allocation.pk)),
+            fetch_redirect_response=False,
+        )
+
+    def test_post_other_users_project(self, auth_client_factory, project, user_factory):
+        """Test that user cannot create an HX2 allocation for another user's project."""
+        other_user = user_factory()
+        client = auth_client_factory(other_user)
+        response = client.post(
+            self._get_url(), data=dict(project=project.pk, accept_terms=True)
+        )
+        assert response.status_code == 200
+        assert response.context["form"].errors["project"] == [
+            "Select a valid choice. That choice is not one of the available choices."
+        ]
+
+    def test_get(self, auth_client_factory, project, user_factory, project_factory):
+        """Test that the form is rendered on GET and has the correct choices."""
+        project_factory(pi=user_factory(), title="Other Project")
+
+        client = auth_client_factory(project.pi)
+        response = client.get(self._get_url())
+        assert response.status_code == 200
+        assertTemplateUsed(
+            response, "imperial_coldfront_plugin/hx2_allocation_self_creation.html"
+        )
+        form = response.context["form"]
+        assert form.fields["project"].queryset.get() == project
+        assert not form.fields["accept_terms"].initial

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -51,12 +51,6 @@ def get_graph_api_client_mock(mocker, parsed_profile):
     return mock
 
 
-@pytest.fixture
-def allocation_active_status():
-    """Fixture for an active allocation status choice."""
-    return AllocationStatusChoice.objects.create(name="Active")
-
-
 class TestHomeView:
     """Test rendering of the home view.
 


### PR DESCRIPTION
# Description

Fixes #353

A fairly simple implementation of the issue as described with:
- a form to allow project/group selection and T&Cs acceptance
- a view to display the form and process
- templates
- placeholder terms and conditions text

Also made a small supporting refactor to add a `project_factory` fixture to make it a bit easier to create projects in tests.

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [X] All tests pass (eg. `python -m pytest`)
- [ ] The documentation builds and looks OK (eg. `python -m sphinx -b html docs docs/build`)
- [X] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)

## Further checks

- [X] Code is commented, particularly in hard-to-understand areas
- [X] Tests added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
