### PR TITLE
Add navbar item for requesting rcs resources

### DIFF
--- a/imperial_coldfront_plugin/settings.py
+++ b/imperial_coldfront_plugin/settings.py
@@ -189,3 +189,6 @@ RDF_ALLOCATION_EXPIRY_UNLINK_DAYS = 7
 
 ENABLE_USER_GROUP_CREATION = ENV.bool("ENABLE_USER_GROUP_CREATION", default=False)
 """Feature flag to enable or disable creation of user groups for allocations."""
+
+RDF_ASK_TICKET_URL = ENV.str("RDF_ASK_TICKET_URL", default="")
+"""URL of the form for users to request RDF access."""

--- a/imperial_coldfront_plugin/templates/imperial_coldfront_plugin/navbar_request.html
+++ b/imperial_coldfront_plugin/templates/imperial_coldfront_plugin/navbar_request.html
@@ -1,0 +1,8 @@
+<li id="navbar-request" class="nav-item dropdown">
+  <a class="nav-link dropdown-toggle" href="#" data-toggle="dropdown">Request Access to RCS Resources</a>
+  <div class="dropdown-menu">
+    <a class="dropdown-item" href="{{ settings.RDF_ASK_TICKET_URL }}">Request RDF Allocation</a>
+    <a class="dropdown-item"
+       href="{% url 'imperial_coldfront_plugin:user_create_hx2_allocation' %}">Request HX2 Access</a>
+  </div>
+</li>

--- a/imperial_coldfront_plugin/templates/imperial_coldfront_plugin/navbar_request.html
+++ b/imperial_coldfront_plugin/templates/imperial_coldfront_plugin/navbar_request.html
@@ -2,7 +2,9 @@
   <a class="nav-link dropdown-toggle" href="#" data-toggle="dropdown">Request Access to RCS Resources</a>
   <div class="dropdown-menu">
     <a class="dropdown-item" href="{{ settings.RDF_ASK_TICKET_URL }}">Request RDF Allocation</a>
-    <a class="dropdown-item"
-       href="{% url 'imperial_coldfront_plugin:user_create_hx2_allocation' %}">Request HX2 Access</a>
+    {% if settings.ENABLE_USER_GROUP_CREATION %}
+      <a class="dropdown-item"
+         href="{% url 'imperial_coldfront_plugin:user_create_hx2_allocation' %}">Request HX2 Access</a>
+    {% endif %}
   </div>
 </li>

--- a/imperial_coldfront_plugin/templates/imperial_coldfront_plugin/overrides/authorized_navbar.html
+++ b/imperial_coldfront_plugin/templates/imperial_coldfront_plugin/overrides/authorized_navbar.html
@@ -1,5 +1,6 @@
 {% include 'common/navbar_brand.html' %}
 {% load common_tags %}
+{% load projects %}
 
 <nav class="navbar navbar-expand-md navbar-dark bg-primary">
   <div class="container">
@@ -37,6 +38,10 @@
         {% endif %}
         {% if request.user.is_superuser or perms.allocation.can_manage_invoice %}
           {% include 'common/navbar_invoice.html' %}
+        {% endif %}
+        {% user_owns_projects request.user as show_request_navbar %}
+        {% if show_request_navbar %}
+          {% include 'imperial_coldfront_plugin/navbar_request.html' %}
         {% endif %}
         {% if settings.CENTER_HELP_URL %}
           {% include 'common/navbar_help.html' %}

--- a/imperial_coldfront_plugin/templatetags/projects.py
+++ b/imperial_coldfront_plugin/templatetags/projects.py
@@ -46,6 +46,19 @@ def get_user_owned_projects(user: "User") -> QuerySet[ICLProject]:
 
 
 @register.simple_tag
+def user_owns_projects(user: "User") -> bool:
+    """Return whether a user owns any projects.
+
+    Args:
+      user: The user to check.
+
+    Returns:
+        True if the user owns at least one active project.
+    """
+    return get_user_owned_projects(user).exists()
+
+
+@register.simple_tag
 def user_can_self_create_project(user: "User") -> bool:
     """Return whether a user is eligible to self-create a project.
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,7 @@
 
 import datetime
 import pkgutil
+from pathlib import Path
 from random import choices
 from string import ascii_lowercase
 
@@ -12,8 +13,11 @@ from django.test import Client
 
 def pytest_configure():
     """Configure Django settings for standalone test suite execution."""
+    import coldfront
+
     from imperial_coldfront_plugin import settings as plugin_settings
 
+    coldfront_templates_path = Path(coldfront.__path__[0]) / "templates"
     settings.configure(
         DEBUG=True,
         DATABASES={
@@ -48,7 +52,7 @@ def pytest_configure():
         TEMPLATES=[
             {
                 "BACKEND": "django.template.backends.django.DjangoTemplates",
-                "DIRS": ["tests/templates"],
+                "DIRS": ["tests/templates", str(coldfront_templates_path)],
                 "APP_DIRS": True,
                 "OPTIONS": {
                     "context_processors": [
@@ -77,7 +81,15 @@ def pytest_configure():
         EMAIL_SIGNATURE="",
         CENTER_NAME="",
         CENTER_BASE_URL="",
-        SETTINGS_EXPORT=["SHOW_CREDIT_BALANCE", "ENABLE_USER_GROUP_CREATION"],
+        CENTER_HELP_URL="",
+        ALLOCATION_ACCOUNT_ENABLED=False,
+        SETTINGS_EXPORT=[
+            "SHOW_CREDIT_BALANCE",
+            "ENABLE_USER_GROUP_CREATION",
+            "ALLOCATION_ACCOUNT_ENABLED",
+            "CENTER_HELP_URL",
+            "RDF_ASK_TICKET_URL",
+        ],
         **{
             key: getattr(plugin_settings, key)
             for key in dir(plugin_settings)
@@ -100,6 +112,7 @@ def pytest_configure():
             GPFS_ALLOCATION_CREATION_SLEEP=0,
             ENABLE_RDF_ALLOCATION_LIFECYCLE=True,
             ENABLE_USER_GROUP_CREATION=True,
+            RDF_ASK_TICKET_URL="http://example.com/ticket",
         ),  # override settings loaded by env var for tests
     )
 

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -51,6 +51,46 @@ def get_graph_api_client_mock(mocker, parsed_profile):
     return mock
 
 
+class TestRequestNavbar:
+    """Test the rendering of the request navbar items."""
+
+    @pytest.fixture
+    def request_(self, rf, user):
+        """A request object with a user."""
+        request = rf.get("/")
+        request.user = user
+        return request
+
+    template_path = "imperial_coldfront_plugin/overrides/authorized_navbar.html"
+
+    def test_normal_user(self, request_, settings):
+        """Test that the navbar renders correctly for a normal user."""
+        response = render(request_, self.template_path)
+        assert response.status_code == 200
+        soup = BeautifulSoup(response.content, "html.parser")
+        assert not soup.find("a", id="navbar-request")
+        assert not soup.find(
+            "a", href=reverse("imperial_coldfront_plugin:user_create_group")
+        )
+        assert not soup.find("a", href=settings.RDF_ASK_TICKET_URL)
+
+    def test_project_owner(self, request_, settings, project):
+        """Test that the navbar renders correctly for a project owner."""
+        response = render(request_, self.template_path)
+        assert response.status_code == 200
+        soup = BeautifulSoup(response.content, "html.parser")
+        navbar = soup.find("li", id="navbar-request", class_="nav-item dropdown")
+        assert navbar
+        assert navbar.find(
+            "a",
+            href=reverse("imperial_coldfront_plugin:user_create_hx2_allocation"),
+            class_="dropdown-item",
+        )
+        assert navbar.find(
+            "a", href=settings.RDF_ASK_TICKET_URL, class_="dropdown-item"
+        )
+
+
 class TestHomeView:
     """Test rendering of the home view.
 

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -90,6 +90,23 @@ class TestRequestNavbar:
             "a", href=settings.RDF_ASK_TICKET_URL, class_="dropdown-item"
         )
 
+    def test_feature_flag(self, request_, settings, project):
+        """Test that hx2 link is hidden when the feature flag is disabled."""
+        settings.ENABLE_USER_GROUP_CREATION = False
+        response = render(request_, self.template_path)
+        assert response.status_code == 200
+        soup = BeautifulSoup(response.content, "html.parser")
+        navbar = soup.find("li", id="navbar-request", class_="nav-item dropdown")
+        assert navbar
+        assert not navbar.find(
+            "a",
+            href=reverse("imperial_coldfront_plugin:user_create_hx2_allocation"),
+            class_="dropdown-item",
+        )
+        assert navbar.find(
+            "a", href=settings.RDF_ASK_TICKET_URL, class_="dropdown-item"
+        )
+
 
 class TestHomeView:
     """Test rendering of the home view.

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -68,7 +68,7 @@ class TestRequestNavbar:
         response = render(request_, self.template_path)
         assert response.status_code == 200
         soup = BeautifulSoup(response.content, "html.parser")
-        assert not soup.find("a", id="navbar-request")
+        assert not soup.find("li", id="navbar-request")
         assert not soup.find(
             "a", href=reverse("imperial_coldfront_plugin:user_create_group")
         )

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -19,6 +19,7 @@ urlpatterns = [
     path(
         "/allocation_detail/<int:allocation_pk>/", dummy_view, name="allocation-detail"
     ),
+    path("allocation_list/", dummy_view, name="allocation-list"),
     path("<int:pk>/", dummy_view, name="project-detail"),
     path("project/", dummy_view, name="project-list"),
     path(
@@ -32,4 +33,7 @@ urlpatterns = [
         name="project-note-add",
     ),
     path("resource/<int:resource_pk>", dummy_view, name="resource-detail"),
+    path("resource_list/", dummy_view, name="resource-list"),
+    path("user_profile/", dummy_view, name="user-profile"),
+    path("logout/", dummy_view, name="logout"),
 ]


### PR DESCRIPTION
# Description

Fixes #354 

This PR adds a navbar item visible only to project/group owners that provides links to relevant views.

Some updates to testing gubbins was needed to allow testing the navbar template in isolation.

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [ ] All tests pass (eg. `python -m pytest`)
- [ ] The documentation builds and looks OK (eg. `python -m sphinx -b html docs docs/build`)
- [ ] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
