### PR TITLE
Prevent HX2Allocation from being created if it already exists for the project

### DIFF
--- a/imperial_coldfront_plugin/forms.py
+++ b/imperial_coldfront_plugin/forms.py
@@ -14,6 +14,7 @@ from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.core.exceptions import ValidationError
 from django.core.validators import MinValueValidator
+from django.db.models import Subquery
 from django.http.request import QueryDict
 from django.shortcuts import get_object_or_404
 from django.utils import timezone
@@ -25,7 +26,7 @@ from imperial_coldfront_plugin.utils import (
 
 from .dart import DartIDValidationError, validate_dart_id
 from .microsoft_graph_client import get_graph_api_client
-from .models import CreditTransaction
+from .models import CreditTransaction, HX2Allocation
 
 if TYPE_CHECKING:
     from django.contrib.auth.models import User as UserType
@@ -379,8 +380,13 @@ class CreditTransactionForm(forms.ModelForm["CreditTransaction"]):
 class HXAllocationForm(forms.Form):
     """Form for creating a new HX2 allocation."""
 
+    # This filters for projects that don't currently have a HX2 allocation.
+    # When functionality for HX3 is added, this filter may need to be removed
+    # or amended to allow projects with HX2 but not HX3 allocations to be selected.
     project: forms.ModelChoiceField[ICLProject] = forms.ModelChoiceField(
-        queryset=ICLProject.objects.filter(status__name="Active"),
+        queryset=ICLProject.objects.filter(status__name="Active").exclude(
+            id__in=Subquery(HX2Allocation.objects.values("project_id"))
+        ),
         widget=_js_select_widget(),
     )
 

--- a/imperial_coldfront_plugin/forms.py
+++ b/imperial_coldfront_plugin/forms.py
@@ -14,7 +14,6 @@ from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.core.exceptions import ValidationError
 from django.core.validators import MinValueValidator
-from django.db.models import Subquery
 from django.http.request import QueryDict
 from django.shortcuts import get_object_or_404
 from django.utils import timezone
@@ -26,7 +25,7 @@ from imperial_coldfront_plugin.utils import (
 
 from .dart import DartIDValidationError, validate_dart_id
 from .microsoft_graph_client import get_graph_api_client
-from .models import CreditTransaction, HX2Allocation
+from .models import CreditTransaction
 
 if TYPE_CHECKING:
     from django.contrib.auth.models import User as UserType
@@ -385,7 +384,7 @@ class HXAllocationForm(forms.Form):
     # or amended to allow projects with HX2 but not HX3 allocations to be selected.
     project: forms.ModelChoiceField[ICLProject] = forms.ModelChoiceField(
         queryset=ICLProject.objects.filter(status__name="Active").exclude(
-            id__in=Subquery(HX2Allocation.objects.values("project_id"))
+            allocation__resources__name="HX2"
         ),
         widget=_js_select_widget(),
     )

--- a/imperial_coldfront_plugin/signals.py
+++ b/imperial_coldfront_plugin/signals.py
@@ -339,3 +339,18 @@ def allocation_expiry_zero_quota(
         "imperial_coldfront_plugin.tasks.zero_allocation_gpfs_quota",
         instance.pk,
     )
+
+
+@receiver(pre_save, sender=HX2Allocation)
+def prevent_multiple_hx2_allocations_per_project(
+    sender: type[HX2Allocation],
+    instance: HX2Allocation,
+    **kwargs: object,
+) -> None:
+    """Prevent saving HX2Allocation if the project already has an HX2Allocation."""
+    if instance.pk:
+        # Skip check on updates to existing HX2Allocations
+        return
+
+    if HX2Allocation.objects.filter(project=instance.project).exists():
+        raise ValueError(f"Project {instance.project} already has an HX2 allocation.")

--- a/imperial_coldfront_plugin/signals.py
+++ b/imperial_coldfront_plugin/signals.py
@@ -348,7 +348,10 @@ def prevent_multiple_hx2_allocations_per_project(
     **kwargs: object,
 ) -> None:
     """Prevent saving HX2Allocation if the project already has an HX2Allocation."""
-    existing_allocations = HX2Allocation.objects.filter(project=instance.project)
+    existing_allocations = HX2Allocation.objects.filter(
+        project=instance.project,
+        resources__name="HX2",
+    )
 
     if instance.pk is not None:
         existing_allocations = existing_allocations.exclude(pk=instance.pk)

--- a/imperial_coldfront_plugin/signals.py
+++ b/imperial_coldfront_plugin/signals.py
@@ -348,9 +348,10 @@ def prevent_multiple_hx2_allocations_per_project(
     **kwargs: object,
 ) -> None:
     """Prevent saving HX2Allocation if the project already has an HX2Allocation."""
-    if instance.pk:
-        # Skip check on updates to existing HX2Allocations
-        return
+    existing_allocations = HX2Allocation.objects.filter(project=instance.project)
 
-    if HX2Allocation.objects.filter(project=instance.project).exists():
+    if instance.pk is not None:
+        existing_allocations = existing_allocations.exclude(pk=instance.pk)
+
+    if existing_allocations.exists():
         raise ValueError(f"Project {instance.project} already has an HX2 allocation.")

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -8,6 +8,7 @@ from django.conf import settings
 from imperial_coldfront_plugin.forms import (
     AdminProjectCreationForm,
     CreditTransactionForm,
+    HXAllocationForm,
     RDFAllocationForm,
     UserProjectCreationForm,
     get_department_choices,
@@ -380,3 +381,17 @@ def test_credit_transaction_form_missing_description(project):
     form = CreditTransactionForm(data=form_data)
     assert not form.is_valid()
     assert "description" in form.errors
+
+
+class TestHXAllocationForm:
+    """Tests for HXAllocationForm."""
+
+    def test_project_queryset(self, project):
+        """Test that the project queryset is limited to projects with a PI."""
+        form = HXAllocationForm()
+        assert list(form.fields["project"].queryset.all()) == [project]
+
+    def test_project_queryset_existing_hx2_allocation(self, hx2_allocation):
+        """Test project queryset excludes projects with existing HX2 allocation."""
+        form = HXAllocationForm()
+        assert not form.fields["project"].queryset.exists()

--- a/tests/test_signals.py
+++ b/tests/test_signals.py
@@ -728,6 +728,7 @@ class TestPreventMultipleHX2AllocationsPerProject:
 
         assert allocation.pk is not None
         assert allocation.resources.filter(pk=hx2_resource.pk).exists()
+
     def test_duplicate_allocation_raises(
         self, hx2_allocation, rdf_allocation_dependencies
     ):

--- a/tests/test_signals.py
+++ b/tests/test_signals.py
@@ -730,11 +730,9 @@ class TestPreventMultipleHX2AllocationsPerProject:
         assert allocation.resources.filter(pk=hx2_resource.pk).exists()
 
     def test_duplicate_allocation_raises(
-        self, hx2_allocation, rdf_allocation_dependencies
+        self, hx2_allocation, rdf_allocation_dependencies, allocation_active_status
     ):
         """Test that creating a second HX2 allocation for the same project raises."""
-        allocation_active_status = AllocationStatusChoice.objects.get(name="Active")
-
         # Since the hx2_allocation fixture creates an HX2 allocation for the project,
         # trying to create another one should raise a ValueError.
         with pytest.raises(ValueError, match="already has an HX2 allocation"):

--- a/tests/test_signals.py
+++ b/tests/test_signals.py
@@ -8,8 +8,8 @@ from coldfront.core.allocation.models import (
     AllocationStatusChoice,
     AllocationUser,
     AllocationUserStatusChoice,
-    Resource,
 )
+from coldfront.core.resource.models import Resource
 
 from imperial_coldfront_plugin.models import HX2Allocation, RDFAllocation
 

--- a/tests/test_signals.py
+++ b/tests/test_signals.py
@@ -726,13 +726,15 @@ class TestPreventMultipleHX2AllocationsPerProject:
         )
         allocation.resources.add(hx2_resource)
 
+        assert allocation.pk is not None
+        assert allocation.resources.filter(pk=hx2_resource.pk).exists()
     def test_duplicate_allocation_raises(
         self, hx2_allocation, rdf_allocation_dependencies
     ):
         """Test that creating a second HX2 allocation for the same project raises."""
         allocation_active_status = AllocationStatusChoice.objects.get(name="Active")
 
-        # Since the hx2_allocation fixuture creates an HX2 allocation for the project,
+        # Since the hx2_allocation fixture creates an HX2 allocation for the project,
         # trying to create another one should raise a ValueError.
         with pytest.raises(ValueError, match="already has an HX2 allocation"):
             HX2Allocation.objects.create(

--- a/tests/test_signals.py
+++ b/tests/test_signals.py
@@ -8,9 +8,10 @@ from coldfront.core.allocation.models import (
     AllocationStatusChoice,
     AllocationUser,
     AllocationUserStatusChoice,
+    Resource,
 )
 
-from imperial_coldfront_plugin.models import RDFAllocation
+from imperial_coldfront_plugin.models import HX2Allocation, RDFAllocation
 
 
 @pytest.fixture
@@ -711,3 +712,30 @@ class TestAllocationExpiryZeroQuota:
         rdf_allocation.status = expired_status
         rdf_allocation.save()
         zero_quota_mock.assert_not_called()
+
+
+class TestPreventMultipleHX2AllocationsPerProject:
+    """Tests for prevent_multiple_hx2_allocations_per_project signal handler."""
+
+    def test_new_allocation_passes(self, project, rdf_allocation_dependencies):
+        """Test that creating a first HX2 allocation for a project passes."""
+        hx2_resource = Resource.objects.get(name="HX2")
+        allocation_active_status = AllocationStatusChoice.objects.get(name="Active")
+        allocation = HX2Allocation.objects.create(
+            project=project, status=allocation_active_status
+        )
+        allocation.resources.add(hx2_resource)
+
+    def test_duplicate_allocation_raises(
+        self, hx2_allocation, rdf_allocation_dependencies
+    ):
+        """Test that creating a second HX2 allocation for the same project raises."""
+        allocation_active_status = AllocationStatusChoice.objects.get(name="Active")
+
+        # Since the hx2_allocation fixuture creates an HX2 allocation for the project,
+        # trying to create another one should raise a ValueError.
+        with pytest.raises(ValueError, match="already has an HX2 allocation"):
+            HX2Allocation.objects.create(
+                project=hx2_allocation.project,
+                status=allocation_active_status,
+            )


### PR DESCRIPTION
…already one associated with the project.

# Description

Add a pre-save signal and tests.

Fixes # (issue)

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [ ] All tests pass (eg. `python -m pytest`)
- [ ] The documentation builds and looks OK (eg. `python -m sphinx -b html docs docs/build`)
- [ ] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
