### PR TITLE
Hide expiry banners for non-rdf allocations

### DIFF
--- a/imperial_coldfront_plugin/templates/imperial_coldfront_plugin/overrides/allocation_detail.html
+++ b/imperial_coldfront_plugin/templates/imperial_coldfront_plugin/overrides/allocation_detail.html
@@ -7,7 +7,7 @@
 This is a allocation from an archived group! You cannot make any changes.
 </div>
 {% endif %}
-{% if settings.ENABLE_RDF_ALLOCATION_LIFECYCLE %}
+{% if settings.ENABLE_RDF_ALLOCATION_LIFECYCLE and allocation.get_parent_resource.name == "RDF Active" %}
     {% if allocation.status.name == 'Deleted' %}
     <div class="alert alert-danger" role="alert" id="deleted-allocation">
         <i class="fas fa-trash" aria-hidden="true"></i>

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1243,6 +1243,19 @@ class TestAllocationDetailBanners:
             },
         )
 
+    def test_banner_not_displayed_for_non_rdf_allocations(
+        self, request_, settings, hx2_allocation
+    ):
+        """Test that no banner is displayed for non-RDF allocations."""
+        expired_status, _ = AllocationStatusChoice.objects.get_or_create(name="Expired")
+        hx2_allocation.status = expired_status
+        response = self._render_allocation_detail(request_, hx2_allocation, settings)
+        soup = BeautifulSoup(response.content, "html.parser")
+        assert not soup.find("div", id="expired-allocation")
+        assert not soup.find("div", id="deleted-allocation")
+        assert not soup.find("div", id="removed-allocation")
+        assert not soup.find("div", id="archived-allocation")
+
     def test_banner_displayed_for_expired_allocations(
         self, request_, rdf_allocation, settings
     ):


### PR DESCRIPTION
# Description

#320 added banners displayed at the top of the allocation detail page depending on the status of the allocation. Those banners only make sense when applied to RDF allocations however. At the time those were the only sorts of allocation in use. Now that we have HX2 allocations as well we need extra logic to only show them when relevant.

Fixes #377 

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [ ] All tests pass (eg. `python -m pytest`)
- [ ] The documentation builds and looks OK (eg. `python -m sphinx -b html docs docs/build`)
- [ ] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
