### PR TITLE
Add RCS Access Policy link to user HX2 allocation creation step

### DIFF
--- a/imperial_coldfront_plugin/forms.py
+++ b/imperial_coldfront_plugin/forms.py
@@ -422,5 +422,5 @@ class HX2TermsAndConditionsForm(forms.Form):
     )
     accept_terms = forms.BooleanField(
         required=True,
-        label="I have read and accept the terms and conditions.",
+        label="I accept the terms and conditions of the RCS Access Policy.",
     )

--- a/imperial_coldfront_plugin/settings.py
+++ b/imperial_coldfront_plugin/settings.py
@@ -206,3 +206,6 @@ SERVICE_CHARGING_RATES: dict[str, pint.Quantity[int]] = {
 
 RDF_ASK_TICKET_URL = ENV.str("RDF_ASK_TICKET_URL", default="")
 """URL of the form for users to request RDF access."""
+
+RCS_ACCESS_POLICY_URL = ENV.str("RCS_ACCESS_POLICY_URL", default="")
+"""URL of the RCS access policy document."""

--- a/imperial_coldfront_plugin/templates/imperial_coldfront_plugin/hx2_allocation_self_creation.html
+++ b/imperial_coldfront_plugin/templates/imperial_coldfront_plugin/hx2_allocation_self_creation.html
@@ -7,7 +7,9 @@
         <h2>HX2 Access Terms and Conditions</h2>
       </div>
       <div class="card-body">
-        <p>You must agree to...</p>
+        <p>
+          Terms and conditions of access are given by the <a href="{{ access_policy_url }}">RCS Access Policy</a>.
+        </p>
         <form method="post">
           {% csrf_token %} {{ form|crispy }}
           <div class="mt-4">

--- a/imperial_coldfront_plugin/views.py
+++ b/imperial_coldfront_plugin/views.py
@@ -542,5 +542,5 @@ def user_create_hx2_allocation(request: "AuthenticatedHttpRequest") -> HttpRespo
     return render(
         request,
         "imperial_coldfront_plugin/hx2_allocation_self_creation.html",
-        context=dict(form=form),
+        context=dict(form=form, access_policy_url=settings.RCS_ACCESS_POLICY_URL),
     )

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1397,8 +1397,11 @@ class TestUserCreateHX2AllocationView(LoginRequiredMixin):
             "Select a valid choice. That choice is not one of the available choices."
         ]
 
-    def test_get(self, auth_client_factory, project, user_factory, project_factory):
+    def test_get(
+        self, auth_client_factory, project, user_factory, project_factory, settings
+    ):
         """Test that the form is rendered on GET and has the correct choices."""
+        settings.RCS_ACCESS_POLICY_URL = "https://example.com/rcs-policy"
         project_factory(pi=user_factory(), title="Other Project")
 
         client = auth_client_factory(project.pi)
@@ -1410,6 +1413,11 @@ class TestUserCreateHX2AllocationView(LoginRequiredMixin):
         form = response.context["form"]
         assert form.fields["project"].queryset.get() == project
         assert not form.fields["accept_terms"].initial
+
+        soup = BeautifulSoup(response.content, "html.parser")
+        assert soup.find(
+            "a", href=settings.RCS_ACCESS_POLICY_URL, text="RCS Access Policy"
+        )
 
     def test_feature_flag(self, auth_client_factory, project, user_factory, settings):
         """Test that the view is disabled when the feature flag is off."""


### PR DESCRIPTION
# Description

Update to terms and conditions for the HX2 Allocation creation for m.

Fixes #386 

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [ ] All tests pass (eg. `python -m pytest`)
- [ ] The documentation builds and looks OK (eg. `python -m sphinx -b html docs docs/build`)
- [ ] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
