### PR TITLE
Remove allocation_prevent_multiple_hx2_allocations_per_project signal

### DIFF
--- a/imperial_coldfront_plugin/signals.py
+++ b/imperial_coldfront_plugin/signals.py
@@ -341,26 +341,6 @@ def allocation_expiry_zero_quota(
     )
 
 
-@receiver(pre_save, sender=Allocation)
-@receiver(pre_save, sender=HX2Allocation)
-def allocation_prevent_multiple_hx2_allocations_per_project(
-    sender: type[HX2Allocation],
-    instance: HX2Allocation | Allocation,
-    **kwargs: object,
-) -> None:
-    """Prevent saving HX2Allocation if the project already has an HX2Allocation."""
-    existing_allocations = HX2Allocation.objects.filter(
-        project=instance.project,
-        resources__name="HX2",
-    )
-
-    if instance.pk is not None:
-        existing_allocations = existing_allocations.exclude(pk=instance.pk)
-
-    if existing_allocations.exists():
-        raise ValueError(f"Project {instance.project} already has an HX2 allocation.")
-
-
 @receiver(pre_save, sender=AllocationUser)
 def allocation_user_prevent_multiple_hx2(
     sender: type[AllocationUser],

--- a/tests/test_signals.py
+++ b/tests/test_signals.py
@@ -10,7 +10,7 @@ from coldfront.core.allocation.models import (
 from coldfront.core.project.models import ProjectAttribute
 from coldfront.core.resource.models import Resource
 
-from imperial_coldfront_plugin.models import HX2Allocation, RDFAllocation
+from imperial_coldfront_plugin.models import RDFAllocation
 
 
 @pytest.fixture
@@ -689,35 +689,6 @@ class TestAllocationExpiryZeroQuota:
         zero_quota_mock.assert_not_called()
 
 
-@pytest.mark.parametrize("allocation_cls", (Allocation, HX2Allocation))
-class TestPreventMultipleHX2AllocationsPerProject:
-    """Tests for prevent_multiple_hx2_allocations_per_project signal handler."""
-
-    def test_new_allocation_passes(
-        self, allocation_cls, project, allocation_active_status, hx2_resource
-    ):
-        """Test that creating a first HX2 allocation for a project passes."""
-        allocation = allocation_cls.objects.create(
-            project=project, status=allocation_active_status
-        )
-        allocation.resources.add(hx2_resource)
-
-        assert allocation.pk is not None
-        assert allocation.get_parent_resource.name == "HX2"
-
-    def test_duplicate_allocation_raises(
-        self, allocation_cls, hx2_allocation, allocation_active_status
-    ):
-        """Test that creating a second HX2 allocation for the same project raises."""
-        # Since the hx2_allocation fixture creates an HX2 allocation for the project,
-        # trying to create another one should raise a ValueError.
-        with pytest.raises(ValueError, match="already has an HX2 allocation"):
-            allocation_cls.objects.create(
-                project=hx2_allocation.project,
-                status=allocation_active_status,
-            )
-
-
 class TestAllocationUserPreventMultipleHX2:
     """Tests for allocation_user_prevent_multiple_hx2 signal handler."""
 
@@ -743,7 +714,7 @@ class TestAllocationUserPreventMultipleHX2:
         with pytest.raises(ValueError):
             AllocationUser.objects.create(
                 allocation=new_allocation,
-                user=hx2_allocation_user,
+                user=hx2_allocation_user.user,
                 status=allocation_user_active_status,
             )
 
@@ -767,6 +738,25 @@ class TestAllocationUserPreventMultipleHX2:
             status=allocation_active_status,
         )
         another_allocation.resources.add(Resource.objects.get(name="HX2"))
+        AllocationUser.objects.create(
+            allocation=another_allocation,
+            user=hx2_allocation_user.user,
+            status=allocation_user_active_status,
+        )
+
+    def test_other_allocation_types_allowed(
+        self,
+        new_project,
+        hx2_allocation_user,
+        allocation_user_active_status,
+        allocation_active_status,
+    ):
+        """Test user can be added to multiple allocations if only one is HX2."""
+        # create another non-HX2 allocation and add user
+        another_allocation = Allocation.objects.create(
+            project=new_project,
+            status=allocation_active_status,
+        )
         AllocationUser.objects.create(
             allocation=another_allocation,
             user=hx2_allocation_user.user,

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -471,6 +471,23 @@ class TestAddHXAllocation(LoginRequiredMixin):
         assert response.status_code == 200
         assert response.context["form"].errors
 
+    def test_form_validation_existing_hx2(
+        self, superuser_client, project, hx2_allocation
+    ):
+        """Test creating a second HX2 allocation for the same project is blocked."""
+        response = superuser_client.post(
+            self._get_url(),
+            data=self._make_form_data(project, resource_type="hx2"),
+        )
+
+        # Form validation error should not raise an exception, but should re-render
+        # the form (200 response)
+        assert response.status_code == 200
+        form = response.context["form"]
+        assert form.errors["project"] == [
+            "Select a valid choice. That choice is not one of the available choices."
+        ]
+
 
 class TestAllocationTaskResult(LoginRequiredMixin):
     """Tests for the allocation_task_result view."""

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -477,7 +477,7 @@ class TestAddHXAllocation(LoginRequiredMixin):
         """Test creating a second HX2 allocation for the same project is blocked."""
         response = superuser_client.post(
             self._get_url(),
-            data=self._make_form_data(project, resource_type="hx2"),
+            data=self._make_form_data(project.pk, resource_type="hx2"),
         )
 
         # Form validation error should not raise an exception, but should re-render


### PR DESCRIPTION
# Description

This removes a signal that was designed to prevent multiple HX2 allocations from being created for a project. The signal was overly broad and prevented the creation of any new allocation for the project. The signal was removed entirely as, given the way resources and allocations are associated, it's not possible to do this sort of filtering in a pre_save allocation signal. Instead we'll have to rely on the validation check of `HXAllocationForm`. Added a test to show that this works as required.

Fixes # (issue)

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [ ] All tests pass (eg. `python -m pytest`)
- [ ] The documentation builds and looks OK (eg. `python -m sphinx -b html docs docs/build`)
- [ ] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
