### PR TITLE
341 credit allocation on creation

### DIFF
--- a/imperial_coldfront_plugin/forms.py
+++ b/imperial_coldfront_plugin/forms.py
@@ -190,11 +190,11 @@ class RDFAllocationForm(forms.Form):
     )
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
-        """Initialise form and remove auto-credit fields when feature is disabled."""
+        """Initialise form and hide auto-credit fields when feature is disabled."""
         super().__init__(*args, **kwargs)
         if not settings.ENABLE_RDF_ALLOCATION_AUTO_CREDIT:
-            self.fields.pop("create_credit_transaction")
-            self.fields.pop("credit_transaction_description")
+            self.fields["create_credit_transaction"].widget = forms.HiddenInput()
+            self.fields["credit_transaction_description"].widget = forms.HiddenInput()
 
     def clean_dart_id(self) -> str:
         """Validate provided Dart ID."""
@@ -233,16 +233,12 @@ class RDFAllocationForm(forms.Form):
         if not settings.ENABLE_RDF_ALLOCATION_AUTO_CREDIT:
             return cleaned_data
 
-        create_credit_transaction = bool(
-            cleaned_data.get("create_credit_transaction", False)
-        )
-        if not create_credit_transaction:
-            cleaned_data["credit_transaction_description"] = ""
+        if not cleaned_data.get("create_credit_transaction"):
             return cleaned_data
 
-        description = (cleaned_data.get("credit_transaction_description") or "").strip()
-
-        cleaned_data["credit_transaction_description"] = description
+        cleaned_data["credit_transaction_description"] = (
+            cleaned_data.get("credit_transaction_description") or ""
+        ).strip()
 
         project = cleaned_data.get("project")
         size = cleaned_data.get("size")

--- a/imperial_coldfront_plugin/forms.py
+++ b/imperial_coldfront_plugin/forms.py
@@ -5,7 +5,7 @@ This module contains form classes used for research group management.
 
 from collections.abc import Iterable
 from datetime import date, timedelta
-from typing import TYPE_CHECKING, Any, ClassVar, TypedDict
+from typing import TYPE_CHECKING, Any, ClassVar, NotRequired, TypedDict
 
 from coldfront.core.allocation.models import AllocationAttribute
 from coldfront.core.project.forms import ProjectAddUsersToAllocationForm
@@ -22,6 +22,7 @@ from django.utils import timezone
 from imperial_coldfront_plugin.models import ICLProject
 from imperial_coldfront_plugin.utils import (
     get_allocation_shortname,
+    get_rdf_allocation_credit_projection,
 )
 
 from .dart import DartIDValidationError, validate_dart_id
@@ -132,6 +133,8 @@ class AllocationFormData(TypedDict):
     size: int
     dart_id: str
     allocation_shortname: str
+    create_credit_transaction: NotRequired[bool]
+    credit_transaction_description: NotRequired[str]
 
 
 class RDFAllocationForm(forms.Form):
@@ -172,6 +175,26 @@ class RDFAllocationForm(forms.Form):
         max_length=settings.ALLOCATION_SHORTNAME_MAX_LENGTH,
         validators=[filesystem_path_component_validator],
     )
+    create_credit_transaction = forms.BooleanField(
+        required=False,
+        initial=True,
+        help_text=(
+            "Create a debit transaction from the requested storage size and duration."
+        ),
+    )
+    credit_transaction_description = forms.CharField(
+        required=False,
+        max_length=255,
+        widget=forms.Textarea(attrs={"rows": 3}),
+        help_text="Description to store on the generated credit transaction.",
+    )
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        """Initialise form and remove auto-credit fields when feature is disabled."""
+        super().__init__(*args, **kwargs)
+        if not settings.ENABLE_RDF_ALLOCATION_AUTO_CREDIT:
+            self.fields.pop("create_credit_transaction")
+            self.fields.pop("credit_transaction_description")
 
     def clean_dart_id(self) -> str:
         """Validate provided Dart ID."""
@@ -193,6 +216,56 @@ class RDFAllocationForm(forms.Form):
             raise ValidationError("Name already in use.")
 
         return shortname
+
+    def clean(self) -> dict[str, Any]:
+        """Validate date ordering and optional auto-credit debit fields."""
+        cleaned_data_raw = super().clean()
+        cleaned_data: dict[str, Any] = (
+            cleaned_data_raw if cleaned_data_raw is not None else {}
+        )
+
+        start_date = cleaned_data.get("start_date")
+        end_date = cleaned_data.get("end_date")
+        if start_date and end_date and end_date < start_date:
+            self.add_error("end_date", "End date must be on or after start date.")
+            return cleaned_data
+
+        if not settings.ENABLE_RDF_ALLOCATION_AUTO_CREDIT:
+            return cleaned_data
+
+        create_credit_transaction = bool(
+            cleaned_data.get("create_credit_transaction", False)
+        )
+        if not create_credit_transaction:
+            cleaned_data["credit_transaction_description"] = ""
+            return cleaned_data
+
+        description = (cleaned_data.get("credit_transaction_description") or "").strip()
+
+        cleaned_data["credit_transaction_description"] = description
+
+        project = cleaned_data.get("project")
+        size = cleaned_data.get("size")
+        if project and size is not None and start_date and end_date:
+            current_balance, debit, projected_balance = (
+                get_rdf_allocation_credit_projection(
+                    project=project,
+                    size_tb=size,
+                    start_date=start_date,
+                    end_date=end_date,
+                )
+            )
+            if projected_balance < 0:
+                self.add_error(
+                    None,
+                    (
+                        "Insufficient project credits for this allocation. "
+                        f"Current balance: {current_balance} credits. "
+                        f"Required debit: {-debit} credits."
+                    ),
+                )
+
+        return cleaned_data
 
 
 class DartIDForm(forms.Form):

--- a/imperial_coldfront_plugin/settings.py
+++ b/imperial_coldfront_plugin/settings.py
@@ -212,3 +212,8 @@ RCS_ACCESS_POLICY_URL = ENV.str("RCS_ACCESS_POLICY_URL", default="")
 
 GENERIC_ASK_REQUEST_URL = "https://servicemgt.imperial.ac.uk/esc?id=sc_cat_item&sys_id=82cd1d2b1b4fe510ce015525464bcb8e&referrer=popular_items"
 """URL of the form for users to request support when no specific form is available."""
+
+ENABLE_RDF_ALLOCATION_AUTO_CREDIT = ENV.bool(
+    "ENABLE_RDF_ALLOCATION_AUTO_CREDIT", default=True
+)
+"""Feature flag to enable or disable automatic credit debits for RDF allocations."""

--- a/imperial_coldfront_plugin/settings.py
+++ b/imperial_coldfront_plugin/settings.py
@@ -214,6 +214,6 @@ GENERIC_ASK_REQUEST_URL = "https://servicemgt.imperial.ac.uk/esc?id=sc_cat_item&
 """URL of the form for users to request support when no specific form is available."""
 
 ENABLE_RDF_ALLOCATION_AUTO_CREDIT = ENV.bool(
-    "ENABLE_RDF_ALLOCATION_AUTO_CREDIT", default=True
+    "ENABLE_RDF_ALLOCATION_AUTO_CREDIT", default=False
 )
 """Feature flag to enable or disable automatic credit debits for RDF allocations."""

--- a/imperial_coldfront_plugin/tasks.py
+++ b/imperial_coldfront_plugin/tasks.py
@@ -18,7 +18,11 @@ from django.db import transaction
 from django.db.models import QuerySet
 from django.utils import timezone
 
-from imperial_coldfront_plugin.models import HX2Allocation, RDFAllocation
+from imperial_coldfront_plugin.models import (
+    CreditTransaction,
+    HX2Allocation,
+    RDFAllocation,
+)
 
 from .emails import (
     Discrepancy,
@@ -35,9 +39,10 @@ from .forms import AllocationFormData
 from .gid import get_new_gid
 from .gpfs_client import FilesetPathInfo, GPFSClient, create_fileset_set_quota
 from .ldap import ldap_create_group, ldap_delete_group, ldap_group_member_search
+from .utils import get_rdf_allocation_credit_projection
 
 
-def create_rdf_allocation(form_data: AllocationFormData) -> int:
+def create_rdf_allocation(form_data: AllocationFormData, authoriser: str = "") -> int:
     """Create an RDF allocation from a validated RDFAllocationForm.
 
     Note that this function interacts with external systems.
@@ -54,6 +59,11 @@ def create_rdf_allocation(form_data: AllocationFormData) -> int:
     project = form_data["project"]
     shortname = form_data["allocation_shortname"]
     ldap_name = f"{settings.LDAP_RDF_SHORTNAME_PREFIX}{shortname}"
+    should_create_credit_transaction = bool(
+        settings.ENABLE_RDF_ALLOCATION_AUTO_CREDIT
+        and form_data.get("create_credit_transaction", True)
+    )
+    credit_transaction_description = form_data.get("credit_transaction_description", "")
 
     shortname_attribute_type = AllocationAttributeType.objects.get(name="Shortname")
     location_attribute_type = AllocationAttributeType.objects.get(
@@ -77,6 +87,29 @@ def create_rdf_allocation(form_data: AllocationFormData) -> int:
 
     logger.info("Creating initial database entries for RDF allocation.")
     with transaction.atomic():
+        if should_create_credit_transaction:
+            current_balance, debit, projected_balance = (
+                get_rdf_allocation_credit_projection(
+                    project=project,
+                    size_tb=storage_size_tb,
+                    start_date=form_data["start_date"],
+                    end_date=form_data["end_date"],
+                )
+            )
+            if projected_balance < 0:
+                raise ValueError(
+                    "Insufficient project credits for this allocation. "
+                    f"Current balance: {current_balance} credits. "
+                    f"Required debit: {-debit} credits."
+                )
+
+            CreditTransaction.objects.create(
+                project=project,
+                amount=debit,
+                description=credit_transaction_description,
+                authoriser=authoriser,
+            )
+
         rdf_allocation = RDFAllocation.objects.create(
             project=project,
             status=allocation_active_status,

--- a/imperial_coldfront_plugin/tasks.py
+++ b/imperial_coldfront_plugin/tasks.py
@@ -21,6 +21,7 @@ from django.utils import timezone
 from imperial_coldfront_plugin.models import (
     CreditTransaction,
     HX2Allocation,
+    ICLProject,
     RDFAllocation,
 )
 
@@ -40,6 +41,39 @@ from .gid import get_new_gid
 from .gpfs_client import FilesetPathInfo, GPFSClient, create_fileset_set_quota
 from .ldap import ldap_create_group, ldap_delete_group, ldap_group_member_search
 from .utils import get_rdf_allocation_credit_projection
+
+
+def _create_rdf_allocation_debit_transaction(
+    *,
+    project: ICLProject,
+    size_tb: int,
+    start_date: date,
+    end_date: date,
+    description: str,
+    authoriser: str,
+) -> ICLProject:
+    """Create a debit transaction for an RDF allocation under a project row lock."""
+    locked_project = ICLProject.objects.select_for_update().get(pk=project.pk)
+    current_balance, debit, projected_balance = get_rdf_allocation_credit_projection(
+        project=locked_project,
+        size_tb=size_tb,
+        start_date=start_date,
+        end_date=end_date,
+    )
+    if projected_balance < 0:
+        raise ValueError(
+            "Insufficient project credits for this allocation. "
+            f"Current balance: {current_balance} credits. "
+            f"Required debit: {-debit} credits."
+        )
+
+    CreditTransaction.objects.create(
+        project=locked_project,
+        amount=debit,
+        description=description,
+        authoriser=authoriser,
+    )
+    return locked_project
 
 
 def create_rdf_allocation(form_data: AllocationFormData, authoriser: str = "") -> int:
@@ -88,24 +122,11 @@ def create_rdf_allocation(form_data: AllocationFormData, authoriser: str = "") -
     logger.info("Creating initial database entries for RDF allocation.")
     with transaction.atomic():
         if should_create_credit_transaction:
-            current_balance, debit, projected_balance = (
-                get_rdf_allocation_credit_projection(
-                    project=project,
-                    size_tb=storage_size_tb,
-                    start_date=form_data["start_date"],
-                    end_date=form_data["end_date"],
-                )
-            )
-            if projected_balance < 0:
-                raise ValueError(
-                    "Insufficient project credits for this allocation. "
-                    f"Current balance: {current_balance} credits. "
-                    f"Required debit: {-debit} credits."
-                )
-
-            CreditTransaction.objects.create(
+            project = _create_rdf_allocation_debit_transaction(
                 project=project,
-                amount=debit,
+                size_tb=storage_size_tb,
+                start_date=form_data["start_date"],
+                end_date=form_data["end_date"],
                 description=credit_transaction_description,
                 authoriser=authoriser,
             )

--- a/imperial_coldfront_plugin/utils.py
+++ b/imperial_coldfront_plugin/utils.py
@@ -3,6 +3,7 @@
 from datetime import date
 from math import ceil
 
+import pint
 from coldfront.core.allocation.models import Allocation, AllocationAttribute
 from django.conf import settings
 from django.db.models import Sum
@@ -35,19 +36,20 @@ def get_allocation_shortname(allocation: Allocation) -> str:
         return ""
 
 
-def calculate_credit_balance(project: ICLProject) -> int | None:
+def calculate_credit_balance(project: ICLProject) -> int:
     """Return the summed credit balance for a project.
 
     Args:
         project: The project whose credit balance is to be calculated.
 
     Returns:
-        The total credit balance as an integer, or None if there are no transactions.
+        The total credit balance as an integer. Returns 0 if the project has no
+        credit transactions.
     """
     result = CreditTransaction.objects.filter(project=project).aggregate(
         total=Sum("amount")
     )["total"]
-    return result
+    return result or 0
 
 
 def calculate_rdf_allocation_credit_debit(
@@ -74,11 +76,11 @@ def calculate_rdf_allocation_credit_debit(
         raise ValueError("End date must be on or after start date.")
 
     duration_days = (end_date - start_date).days + 1
-    charging_rate_per_tb_year = settings.SERVICE_CHARGING_RATES["rdf_active"].to(
-        "1 / terabyte / year"
-    )
-    charge = charging_rate_per_tb_year.magnitude * size_tb * (duration_days / 365)
-    return -ceil(charge)
+    charging_rate = settings.SERVICE_CHARGING_RATES["rdf_active"]
+    size = size_tb * pint.Unit("terabyte")
+    duration = duration_days * pint.Unit("day")
+    charge = (charging_rate * size * duration).to("dimensionless")
+    return -ceil(charge.magnitude)
 
 
 def get_rdf_allocation_credit_projection(
@@ -98,7 +100,7 @@ def get_rdf_allocation_credit_projection(
     Returns:
         Tuple of current_balance, debit, projected_balance.
     """
-    current_balance = calculate_credit_balance(project) or 0
+    current_balance = calculate_credit_balance(project)
     debit = calculate_rdf_allocation_credit_debit(
         size_tb=size_tb,
         start_date=start_date,

--- a/imperial_coldfront_plugin/utils.py
+++ b/imperial_coldfront_plugin/utils.py
@@ -1,6 +1,9 @@
 """Utility functions for the Imperial Coldfront plugin."""
 
+from datetime import date
+
 from coldfront.core.allocation.models import Allocation, AllocationAttribute
+from django.conf import settings
 from django.db.models import Sum
 
 from imperial_coldfront_plugin.models import (
@@ -31,7 +34,7 @@ def get_allocation_shortname(allocation: Allocation) -> str:
         return ""
 
 
-def calculate_credit_balance(project: ICLProject) -> int:
+def calculate_credit_balance(project: ICLProject) -> int | None:
     """Return the summed credit balance for a project.
 
     Args:
@@ -44,6 +47,63 @@ def calculate_credit_balance(project: ICLProject) -> int:
         total=Sum("amount")
     )["total"]
     return result
+
+
+def calculate_rdf_allocation_credit_debit(
+    size_tb: int,
+    start_date: date,
+    end_date: date,
+) -> int:
+    """Calculate the debit amount for a proposed RDF allocation.
+
+    Debits are represented as negative values.
+
+    Args:
+        size_tb: The requested storage size in terabytes.
+        start_date: Allocation start date.
+        end_date: Allocation end date.
+
+    Returns:
+        The debit amount as a negative integer.
+
+    Raises:
+        ValueError: If end_date precedes start_date.
+    """
+    if end_date < start_date:
+        raise ValueError("End date must be on or after start date.")
+
+    duration_days = (end_date - start_date).days + 1
+    charging_rate_per_tb_year = settings.SERVICE_CHARGING_RATES["rdf_active"].to(
+        "1 / terabyte / year"
+    )
+    charge = charging_rate_per_tb_year.magnitude * size_tb * (duration_days / 365)
+    return -round(charge)
+
+
+def get_rdf_allocation_credit_projection(
+    project: ICLProject,
+    size_tb: int,
+    start_date: date,
+    end_date: date,
+) -> tuple[int, int, int]:
+    """Return current balance, debit and projected balance for an RDF allocation.
+
+    Args:
+        project: Project to evaluate.
+        size_tb: Requested storage size in terabytes.
+        start_date: Allocation start date.
+        end_date: Allocation end date.
+
+    Returns:
+        Tuple of current_balance, debit, projected_balance.
+    """
+    current_balance = calculate_credit_balance(project) or 0
+    debit = calculate_rdf_allocation_credit_debit(
+        size_tb=size_tb,
+        start_date=start_date,
+        end_date=end_date,
+    )
+    return current_balance, debit, current_balance + debit
 
 
 def rdf_or_hx2_allocation(instance: Allocation) -> RDFAllocation | HX2Allocation:

--- a/imperial_coldfront_plugin/utils.py
+++ b/imperial_coldfront_plugin/utils.py
@@ -1,6 +1,7 @@
 """Utility functions for the Imperial Coldfront plugin."""
 
 from datetime import date
+from math import ceil
 
 from coldfront.core.allocation.models import Allocation, AllocationAttribute
 from django.conf import settings
@@ -77,7 +78,7 @@ def calculate_rdf_allocation_credit_debit(
         "1 / terabyte / year"
     )
     charge = charging_rate_per_tb_year.magnitude * size_tb * (duration_days / 365)
-    return -round(charge)
+    return -ceil(charge)
 
 
 def get_rdf_allocation_credit_projection(

--- a/imperial_coldfront_plugin/views.py
+++ b/imperial_coldfront_plugin/views.py
@@ -109,7 +109,11 @@ def add_rdf_storage_allocation(request: HttpRequest) -> HttpResponse:
     if request.method == "POST":
         form = RDFAllocationForm(request.POST)
         if form.is_valid():
-            task_id = async_task(create_rdf_allocation, form.cleaned_data)
+            task_id = async_task(
+                create_rdf_allocation,
+                form.cleaned_data,
+                request.user.username,
+            )
             return redirect(
                 "imperial_coldfront_plugin:allocation_task_result",
                 task_id=task_id,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,6 +15,7 @@ from django.test import Client
 def pytest_configure():
     """Configure Django settings for standalone test suite execution."""
     import coldfront
+    import pint
 
     from imperial_coldfront_plugin import settings as plugin_settings
 
@@ -114,6 +115,9 @@ def pytest_configure():
             ENABLE_RDF_ALLOCATION_LIFECYCLE=True,
             ENABLE_USER_GROUP_CREATION=True,
             RDF_ASK_TICKET_URL="http://example.com/ticket",
+            SERVICE_CHARGING_RATES={
+                "rdf_active": 50 / (pint.Unit("terabyte") * pint.Unit("year")),
+            },
         ),  # override settings loaded by env var for tests
     )
 

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -16,7 +16,7 @@ from imperial_coldfront_plugin.forms import (
     get_faculty_choices,
     get_initial_department_choices,
 )
-from imperial_coldfront_plugin.models import ICLProject
+from imperial_coldfront_plugin.models import CreditTransaction, ICLProject
 
 
 def test_get_faculty_choices():
@@ -142,6 +142,105 @@ def test_rdf_allocation_end_date_initial_value(rdf_form_data, settings):
     assert form["end_date"].initial == datetime.now().date() + timedelta(
         days=settings.ALLOCATION_DEFAULT_PERIOD_DAYS
     )
+
+
+def test_rdf_allocation_form_auto_credit_fields_hidden_when_feature_disabled(settings):
+    """Test auto-credit fields are hidden when the feature flag is disabled."""
+    settings.ENABLE_RDF_ALLOCATION_AUTO_CREDIT = False
+
+    form = RDFAllocationForm()
+
+    assert "create_credit_transaction" not in form.fields
+    assert "credit_transaction_description" not in form.fields
+
+
+def test_rdf_allocation_form_auto_credit_fields_present_when_feature_enabled(settings):
+    """Test auto-credit fields are present when the feature flag is enabled."""
+    settings.ENABLE_RDF_ALLOCATION_AUTO_CREDIT = True
+
+    form = RDFAllocationForm()
+
+    assert "create_credit_transaction" in form.fields
+    assert form.fields["create_credit_transaction"].initial is True
+    assert "credit_transaction_description" in form.fields
+
+
+def test_rdf_allocation_description_not_required_when_auto_credit_disabled(
+    settings, rdf_form_data
+):
+    """Test description is optional when auto-credit checkbox is unticked."""
+    settings.ENABLE_RDF_ALLOCATION_AUTO_CREDIT = True
+
+    rdf_form_data.update(
+        create_credit_transaction=False,
+        credit_transaction_description="",
+    )
+    form = RDFAllocationForm(data=rdf_form_data)
+
+    assert form.is_valid(), f"Form errors: {form.errors}"
+
+
+def test_rdf_allocation_rejects_end_date_before_start_date(settings, rdf_form_data):
+    """Test form rejects end dates before start dates."""
+    settings.ENABLE_RDF_ALLOCATION_AUTO_CREDIT = False
+
+    rdf_form_data.update(
+        start_date=datetime.now().date() + timedelta(days=2),
+        end_date=datetime.now().date() + timedelta(days=1),
+    )
+    form = RDFAllocationForm(data=rdf_form_data)
+
+    assert not form.is_valid()
+    assert form.errors["end_date"] == ["End date must be on or after start date."]
+
+
+def test_rdf_allocation_rejects_when_project_has_insufficient_credit(
+    settings, rdf_form_data, project
+):
+    """Test form blocks submission when project credits are insufficient."""
+    settings.ENABLE_RDF_ALLOCATION_AUTO_CREDIT = True
+    CreditTransaction.objects.create(
+        project=project,
+        amount=0,
+        description="zero seed credit",
+    )
+
+    rdf_form_data.update(
+        start_date=datetime.now().date(),
+        end_date=datetime.now().date(),
+        size=10,
+        create_credit_transaction=True,
+        credit_transaction_description="Auto debit for allocation",
+    )
+    form = RDFAllocationForm(data=rdf_form_data)
+
+    assert not form.is_valid()
+    assert (
+        "Insufficient project credits for this allocation." in form.errors["__all__"][0]
+    )
+
+
+def test_rdf_allocation_accepts_when_project_has_sufficient_credit(
+    settings, rdf_form_data, project
+):
+    """Test form allows submission when project credits cover projected debit."""
+    settings.ENABLE_RDF_ALLOCATION_AUTO_CREDIT = True
+    CreditTransaction.objects.create(
+        project=project,
+        amount=1000,
+        description="large seed credit",
+    )
+
+    rdf_form_data.update(
+        start_date=datetime.now().date(),
+        end_date=datetime.now().date(),
+        size=1,
+        create_credit_transaction=True,
+        credit_transaction_description="Auto debit for allocation",
+    )
+    form = RDFAllocationForm(data=rdf_form_data)
+
+    assert form.is_valid(), f"Form errors: {form.errors}"
 
 
 @pytest.fixture

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -161,7 +161,7 @@ def test_rdf_allocation_form_auto_credit_fields_present_when_feature_enabled(set
     form = RDFAllocationForm()
 
     assert "create_credit_transaction" in form.fields
-    assert form.fields["create_credit_transaction"].initial is True
+    assert form.fields["create_credit_transaction"].initial
     assert "credit_transaction_description" in form.fields
 
 

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -145,13 +145,17 @@ def test_rdf_allocation_end_date_initial_value(rdf_form_data, settings):
 
 
 def test_rdf_allocation_form_auto_credit_fields_hidden_when_feature_disabled(settings):
-    """Test auto-credit fields are hidden when the feature flag is disabled."""
+    """Test auto-credit fields use HiddenInput when the feature flag is disabled."""
     settings.ENABLE_RDF_ALLOCATION_AUTO_CREDIT = False
 
     form = RDFAllocationForm()
 
-    assert "create_credit_transaction" not in form.fields
-    assert "credit_transaction_description" not in form.fields
+    assert isinstance(
+        form.fields["create_credit_transaction"].widget, forms.HiddenInput
+    )
+    assert isinstance(
+        form.fields["credit_transaction_description"].widget, forms.HiddenInput
+    )
 
 
 def test_rdf_allocation_form_auto_credit_fields_present_when_feature_enabled(settings):
@@ -199,11 +203,6 @@ def test_rdf_allocation_rejects_when_project_has_insufficient_credit(
 ):
     """Test form blocks submission when project credits are insufficient."""
     settings.ENABLE_RDF_ALLOCATION_AUTO_CREDIT = True
-    CreditTransaction.objects.create(
-        project=project,
-        amount=0,
-        description="zero seed credit",
-    )
 
     rdf_form_data.update(
         start_date=datetime.now().date(),

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -287,10 +287,12 @@ class TestCreateRDFAllocation:
 
         create_rdf_allocation(form.cleaned_data, authoriser="adminuser")
 
-        debit_transaction = CreditTransaction.objects.get(amount=0)
-        assert debit_transaction.project == project
-        assert debit_transaction.description == "Auto debit for RDF allocation"
-        assert debit_transaction.authoriser == "adminuser"
+        debit_transaction = CreditTransaction.objects.get(
+            project=project,
+            description="Auto debit for RDF allocation",
+            authoriser="adminuser",
+        )
+        assert debit_transaction.amount == -1
 
     def test_success_skips_credit_transaction_when_checkbox_off(
         self,

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -294,6 +294,43 @@ class TestCreateRDFAllocation:
         )
         assert debit_transaction.amount == -1
 
+    def test_success_locks_project_row_for_credit_transaction(
+        self,
+        mocker,
+        project,
+        settings,
+        rdf_form_data,
+        allocation_dependencies,
+    ):
+        """Test task acquires a project row lock before creating debit."""
+        settings.ENABLE_RDF_ALLOCATION_AUTO_CREDIT = True
+        CreditTransaction.objects.create(
+            project=project,
+            amount=100,
+            description="seed credit",
+            authoriser="admin",
+        )
+        rdf_form_data.update(
+            start_date=timezone.now().date(),
+            end_date=timezone.now().date(),
+            size=1,
+            create_credit_transaction=True,
+            credit_transaction_description="Auto debit for RDF allocation",
+        )
+
+        form = RDFAllocationForm(data=rdf_form_data)
+        assert form.is_valid(), f"Form errors: {form.errors}"
+
+        select_for_update_mock = mocker.patch(
+            "imperial_coldfront_plugin.tasks.ICLProject.objects.select_for_update"
+        )
+        select_for_update_mock.return_value.get.return_value = project
+
+        create_rdf_allocation(form.cleaned_data, authoriser="adminuser")
+
+        select_for_update_mock.assert_called_once_with()
+        select_for_update_mock.return_value.get.assert_called_once_with(pk=project.pk)
+
     def test_success_skips_credit_transaction_when_checkbox_off(
         self,
         project,

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -312,9 +312,16 @@ class TestCreateRDFAllocation:
         form = RDFAllocationForm(data=rdf_form_data)
         assert form.is_valid(), f"Form errors: {form.errors}"
 
+        before_count = CreditTransaction.objects.count()
+
         create_rdf_allocation(form.cleaned_data, authoriser="adminuser")
 
-        assert not CreditTransaction.objects.filter(project=project, amount__lt=0)
+        assert CreditTransaction.objects.count() == before_count
+        assert not CreditTransaction.objects.filter(
+            project=project,
+            description="Auto debit for RDF allocation",
+            authoriser="adminuser",
+        ).exists()
 
     def test_insufficient_credit_raises_and_rolls_back(
         self,

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -16,6 +16,7 @@ from django.utils import timezone
 from imperial_coldfront_plugin.forms import RDFAllocationForm
 from imperial_coldfront_plugin.gid import get_new_gid
 from imperial_coldfront_plugin.gpfs_client import FilesetPathInfo
+from imperial_coldfront_plugin.models import CreditTransaction
 from imperial_coldfront_plugin.tasks import (
     check_hx2_ldap_consistency,
     check_rdf_allocation_expiry_notifications,
@@ -257,6 +258,103 @@ class TestCreateRDFAllocation:
             files_quota=settings.GPFS_FILES_QUOTA,
             logger=logging.getLogger("django-q"),
         )
+
+    def test_success_creates_credit_transaction_when_enabled(
+        self,
+        project,
+        settings,
+        rdf_form_data,
+        allocation_dependencies,
+    ):
+        """Test task creates a debit transaction when auto-credit is enabled."""
+        settings.ENABLE_RDF_ALLOCATION_AUTO_CREDIT = True
+        CreditTransaction.objects.create(
+            project=project,
+            amount=100,
+            description="seed credit",
+            authoriser="admin",
+        )
+        rdf_form_data.update(
+            start_date=timezone.now().date(),
+            end_date=timezone.now().date(),
+            size=1,
+            create_credit_transaction=True,
+            credit_transaction_description="Auto debit for RDF allocation",
+        )
+
+        form = RDFAllocationForm(data=rdf_form_data)
+        assert form.is_valid(), f"Form errors: {form.errors}"
+
+        create_rdf_allocation(form.cleaned_data, authoriser="adminuser")
+
+        debit_transaction = CreditTransaction.objects.get(amount=0)
+        assert debit_transaction.project == project
+        assert debit_transaction.description == "Auto debit for RDF allocation"
+        assert debit_transaction.authoriser == "adminuser"
+
+    def test_success_skips_credit_transaction_when_checkbox_off(
+        self,
+        project,
+        settings,
+        rdf_form_data,
+        allocation_dependencies,
+    ):
+        """Test task skips debit creation when auto-credit is disabled in form."""
+        settings.ENABLE_RDF_ALLOCATION_AUTO_CREDIT = True
+        rdf_form_data.update(
+            start_date=timezone.now().date(),
+            end_date=timezone.now().date(),
+            size=1,
+            create_credit_transaction=False,
+            credit_transaction_description="",
+        )
+
+        form = RDFAllocationForm(data=rdf_form_data)
+        assert form.is_valid(), f"Form errors: {form.errors}"
+
+        create_rdf_allocation(form.cleaned_data, authoriser="adminuser")
+
+        assert not CreditTransaction.objects.filter(project=project, amount__lt=0)
+
+    def test_insufficient_credit_raises_and_rolls_back(
+        self,
+        project,
+        settings,
+        rdf_form_data,
+        allocation_dependencies,
+    ):
+        """Test defensive task check blocks allocation when balance changes."""
+        settings.ENABLE_RDF_ALLOCATION_AUTO_CREDIT = True
+        CreditTransaction.objects.create(
+            project=project,
+            amount=10,
+            description="seed credit",
+            authoriser="admin",
+        )
+        rdf_form_data.update(
+            start_date=timezone.now().date(),
+            end_date=timezone.now().date(),
+            size=10,
+            create_credit_transaction=True,
+            credit_transaction_description="Auto debit for RDF allocation",
+        )
+        form = RDFAllocationForm(data=rdf_form_data)
+        assert form.is_valid(), f"Form errors: {form.errors}"
+
+        # Simulate balance reduction between form submit and async task execution.
+        CreditTransaction.objects.create(
+            project=project,
+            amount=-10,
+            description="intervening debit",
+            authoriser="admin",
+        )
+
+        before_count = CreditTransaction.objects.count()
+        with pytest.raises(ValueError, match="Insufficient project credits"):
+            create_rdf_allocation(form.cleaned_data, authoriser="adminuser")
+
+        assert not Allocation.objects.all()
+        assert CreditTransaction.objects.count() == before_count
 
     def test_ldap_rollback(
         gpfs_create_fileset_mock,

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -20,7 +20,6 @@ def test_calculate_credit_balance_returns_sum(project):
     assert calculate_credit_balance(project) == 85
 
 
-@pytest.mark.django_db
 def test_calculate_rdf_allocation_credit_debit_uses_inclusive_days():
     """Test debit calculation uses inclusive day count and rounding."""
     debit = calculate_rdf_allocation_credit_debit(
@@ -30,7 +29,6 @@ def test_calculate_rdf_allocation_credit_debit_uses_inclusive_days():
     assert debit == -5
 
 
-@pytest.mark.django_db
 def test_calculate_rdf_allocation_credit_debit_for_full_year():
     """Test debit calculation for a one-year allocation period."""
     debit = calculate_rdf_allocation_credit_debit(
@@ -42,7 +40,6 @@ def test_calculate_rdf_allocation_credit_debit_for_full_year():
     assert debit == -100
 
 
-@pytest.mark.django_db
 def test_calculate_rdf_allocation_credit_debit_invalid_date_range():
     """Test debit calculation rejects end dates before start dates."""
     with pytest.raises(ValueError, match="End date must be on or after start date"):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -27,7 +27,7 @@ def test_calculate_rdf_allocation_credit_debit_uses_inclusive_days():
         size_tb=1, start_date=date(2026, 1, 1), end_date=date(2026, 2, 1)
     )
 
-    assert debit == -4
+    assert debit == -5
 
 
 @pytest.mark.django_db

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,7 +1,13 @@
+from datetime import date
+
 import pytest
 
 from imperial_coldfront_plugin.models import CreditTransaction
-from imperial_coldfront_plugin.utils import calculate_credit_balance
+from imperial_coldfront_plugin.utils import (
+    calculate_credit_balance,
+    calculate_rdf_allocation_credit_debit,
+    get_rdf_allocation_credit_projection,
+)
 
 
 @pytest.mark.django_db
@@ -12,3 +18,53 @@ def test_calculate_credit_balance_returns_sum(project):
     CreditTransaction.objects.create(project=project, amount=25, description="bonus")
 
     assert calculate_credit_balance(project) == 85
+
+
+@pytest.mark.django_db
+def test_calculate_rdf_allocation_credit_debit_uses_inclusive_days():
+    """Test debit calculation uses inclusive day count and rounding."""
+    debit = calculate_rdf_allocation_credit_debit(
+        size_tb=1, start_date=date(2026, 1, 1), end_date=date(2026, 2, 1)
+    )
+
+    assert debit == -4
+
+
+@pytest.mark.django_db
+def test_calculate_rdf_allocation_credit_debit_for_full_year():
+    """Test debit calculation for a one-year allocation period."""
+    debit = calculate_rdf_allocation_credit_debit(
+        size_tb=2,
+        start_date=date(2026, 1, 1),
+        end_date=date(2026, 12, 31),
+    )
+
+    assert debit == -100
+
+
+@pytest.mark.django_db
+def test_calculate_rdf_allocation_credit_debit_invalid_date_range():
+    """Test debit calculation rejects end dates before start dates."""
+    with pytest.raises(ValueError, match="End date must be on or after start date"):
+        calculate_rdf_allocation_credit_debit(
+            size_tb=1,
+            start_date=date(2026, 1, 2),
+            end_date=date(2026, 1, 1),
+        )
+
+
+@pytest.mark.django_db
+def test_get_rdf_allocation_credit_projection(project):
+    """Test projection returns expected current balance, debit and projected balance."""
+    CreditTransaction.objects.create(project=project, amount=120, description="credit")
+
+    current_balance, debit, projected_balance = get_rdf_allocation_credit_projection(
+        project=project,
+        size_tb=2,
+        start_date=date(2026, 1, 1),
+        end_date=date(2026, 12, 31),
+    )
+
+    assert current_balance == 120
+    assert debit == -100
+    assert projected_balance == 20

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -327,6 +327,7 @@ class TestAddRDFStorageAllocation(LoginRequiredMixin):
         self,
         create_rdf_allocation_mock,
         superuser_client,
+        superuser,
         project,
         rdf_allocation_shortname,
     ):
@@ -359,12 +360,94 @@ class TestAddRDFStorageAllocation(LoginRequiredMixin):
         create_rdf_allocation_mock.assert_called_once()
         called_args, _ = create_rdf_allocation_mock.call_args
         form_data = called_args[0]
+        authoriser = called_args[1]
         assert form_data["project"] == project
         assert form_data["start_date"] == start_date
         assert form_data["end_date"] == end_date
         assert form_data["size"] == size
         assert form_data["allocation_shortname"] == rdf_allocation_shortname
         assert form_data["description"] == description
+        assert authoriser == superuser.username
+
+    @patch("imperial_coldfront_plugin.views.create_rdf_allocation")
+    def test_post_feature_flag_enabled_auto_credit_passes_form_fields(
+        self,
+        create_rdf_allocation_mock,
+        superuser_client,
+        superuser,
+        project,
+        rdf_allocation_shortname,
+        settings,
+    ):
+        """Test that auto-credit fields are passed through when feature is enabled."""
+        settings.ENABLE_RDF_ALLOCATION_AUTO_CREDIT = True
+        CreditTransaction.objects.create(
+            project=project,
+            amount=100,
+            description="seed credit",
+            authoriser=superuser.username,
+        )
+
+        response = superuser_client.post(
+            self._get_url(),
+            data=dict(
+                project=project.pk,
+                start_date=timezone.now().date(),
+                end_date=timezone.now().date(),
+                size=1,
+                allocation_shortname=rdf_allocation_shortname,
+                description="A longer description text.",
+                create_credit_transaction="on",
+                credit_transaction_description="Auto debit for this allocation",
+            ),
+        )
+
+        assert response.status_code == HTTPStatus.FOUND
+        create_rdf_allocation_mock.assert_called_once()
+        called_args, _ = create_rdf_allocation_mock.call_args
+        form_data = called_args[0]
+        authoriser = called_args[1]
+        assert form_data["create_credit_transaction"] is True
+        assert (
+            form_data["credit_transaction_description"]
+            == "Auto debit for this allocation"
+        )
+        assert authoriser == superuser.username
+
+    def test_post_feature_flag_enabled_blocks_insufficient_credit(
+        self,
+        superuser_client,
+        project,
+        rdf_allocation_shortname,
+        settings,
+        mocker,
+    ):
+        """Test submission is blocked when projected auto-debit exceeds credits."""
+        settings.ENABLE_RDF_ALLOCATION_AUTO_CREDIT = True
+        async_task_mock = mocker.patch("imperial_coldfront_plugin.views.async_task")
+
+        response = superuser_client.post(
+            self._get_url(),
+            data=dict(
+                project=project.pk,
+                start_date=timezone.now().date(),
+                end_date=timezone.now().date(),
+                size=10,
+                allocation_shortname=rdf_allocation_shortname,
+                description="A longer description text.",
+                create_credit_transaction="on",
+                credit_transaction_description="Auto debit for this allocation",
+            ),
+        )
+
+        assert response.status_code == HTTPStatus.OK
+        form = response.context["form"]
+        assert not form.is_valid()
+        assert (
+            "Insufficient project credits for this allocation."
+            in form.errors["__all__"][0]
+        )
+        async_task_mock.assert_not_called()
 
     class TestLoadDepartmentsView:
         """Tests for the load_departments view."""


### PR DESCRIPTION
# Description
Added a checkbox to create a credit transaction when requesting RDF allocation. This will calculate the cost of the allocation in credits and then check to see if the project has enough credits if there is it will remove the credits from the project. If there are not enough credits it will state how many are needed. 


Fixes #341 (issue)

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [ ] All tests pass (eg. `python -m pytest`)
- [ ] The documentation builds and looks OK (eg. `python -m sphinx -b html docs docs/build`)
- [ ] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
