### PR TITLE
Round off quota usage

### DIFF
--- a/imperial_coldfront_plugin/tasks.py
+++ b/imperial_coldfront_plugin/tasks.py
@@ -264,7 +264,7 @@ def update_quota_usages_task() -> None:
         storage_attribute_usage.value = round(usages[rdf_id]["block_usage_tb"], 2)
         storage_attribute_usage.save()
         files_attribute_usage = allocation.files_quota_attr.allocationattributeusage
-        files_attribute_usage.value = round(usages[rdf_id]["files_usage"], 2)
+        files_attribute_usage.value = usages[rdf_id]["files_usage"]
         files_attribute_usage.save()
 
 

--- a/imperial_coldfront_plugin/tasks.py
+++ b/imperial_coldfront_plugin/tasks.py
@@ -261,10 +261,10 @@ def update_quota_usages_task() -> None:
         storage_attribute_usage = (
             allocation.storage_quota_tb_attr.allocationattributeusage
         )
-        storage_attribute_usage.value = usages[rdf_id]["block_usage_tb"]
+        storage_attribute_usage.value = round(usages[rdf_id]["block_usage_tb"], 2)
         storage_attribute_usage.save()
         files_attribute_usage = allocation.files_quota_attr.allocationattributeusage
-        files_attribute_usage.value = usages[rdf_id]["files_usage"]
+        files_attribute_usage.value = round(usages[rdf_id]["files_usage"], 2)
         files_attribute_usage.save()
 
 

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -1102,11 +1102,11 @@ class TestUpdateQuotaUsagesTask:
         files_quota_attr,
         files_quota_usage,
     ):
-        """Test that quota usages values are rounded to 2 decimal places."""
+        """Test that quota usages value is rounded to 2 decimal places."""
         retrieve_all_fileset_quotas_mock.return_value = {
             rdf_allocation.shortname: {
                 "block_usage_tb": 1.23456789,
-                "files_usage": 1234.56789,
+                "files_usage": 1234,
             }
         }
 
@@ -1116,4 +1116,4 @@ class TestUpdateQuotaUsagesTask:
         assert storage_quota_usage.value == 1.23
 
         files_quota_usage.refresh_from_db()
-        assert files_quota_usage.value == 1234.57
+        assert files_quota_usage.value == 1234

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -6,6 +6,7 @@ import pytest
 from coldfront.core.allocation.models import (
     Allocation,
     AllocationAttribute,
+    AllocationAttributeUsage,
     AllocationStatusChoice,
     AllocationUser,
 )
@@ -22,6 +23,7 @@ from imperial_coldfront_plugin.tasks import (
     check_rdf_ldap_consistency,
     create_rdf_allocation,
     unlink_expired_allocation_filesets,
+    update_quota_usages_task,
     zero_allocation_gpfs_quota,
 )
 
@@ -1056,3 +1058,62 @@ class TestUnlinkExpiredAllocationFilesets:
         unlink_expired_allocation_filesets()
 
         mock_client.unlink_fileset.assert_not_called()
+
+
+class TestUpdateQuotaUsagesTask:
+    """Tests for update_quota_usages_task."""
+
+    @pytest.fixture
+    def storage_quota_attr(self, rdf_allocation, allocation_attribute_factory):
+        """Fixture to create Storage Quota attribute for the allocation."""
+        return allocation_attribute_factory(
+            name="Storage Quota (TB)", value="10", allocation=rdf_allocation
+        )
+
+    @pytest.fixture
+    def storage_quota_usage(self, storage_quota_attr):
+        """Fixture to create Storage Quota attribute usage for the allocation."""
+        return AllocationAttributeUsage.objects.create(
+            allocation_attribute=storage_quota_attr,
+            value=10.0,
+        )
+
+    @pytest.fixture
+    def files_quota_attr(self, rdf_allocation, allocation_attribute_factory):
+        """Fixture to create Files Quota attribute for the allocation."""
+        return allocation_attribute_factory(
+            name="Files Quota", value="1000", allocation=rdf_allocation
+        )
+
+    @pytest.fixture
+    def files_quota_usage(self, files_quota_attr):
+        """Fixture to create Files Quota attribute usage for the allocation."""
+        return AllocationAttributeUsage.objects.create(
+            allocation_attribute=files_quota_attr,
+            value=1000.0,
+        )
+
+    def test_round_quota_usage_values(
+        self,
+        retrieve_all_fileset_quotas_mock,
+        rdf_allocation,
+        storage_quota_attr,
+        storage_quota_usage,
+        files_quota_attr,
+        files_quota_usage,
+    ):
+        """Test that quota usages values are rounded to 2 decimal places."""
+        retrieve_all_fileset_quotas_mock.return_value = {
+            rdf_allocation.shortname: {
+                "block_usage_tb": 1.23456789,
+                "files_usage": 1234.56789,
+            }
+        }
+
+        update_quota_usages_task()
+
+        storage_quota_usage.refresh_from_db()
+        assert storage_quota_usage.value == 1.23
+
+        files_quota_usage.refresh_from_db()
+        assert files_quota_usage.value == 1234.57


### PR DESCRIPTION
# Description

In `update_quota_usages_task()` the values for storage and file usage are rounded to 2 decimal places before being saved. Included a unit test for the same.

Fixes #398

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [x] All tests pass (eg. `python -m pytest`)
- [ ] The documentation builds and looks OK (eg. `python -m sphinx -b html docs docs/build`)
- [x] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
