### PR TITLE
Fix integration issue with allocation form and project-add-users view

### DIFF
--- a/imperial_coldfront_plugin/forms.py
+++ b/imperial_coldfront_plugin/forms.py
@@ -349,14 +349,11 @@ class ProjectAddUsersToAllocationShortnameForm(ProjectAddUsersToAllocationForm):
             allocation_choices, key=lambda x: x[1][0].lower()
         )
         allocation_choices.insert(0, ("__select_all__", "Select All"))
-        if allocation_query_set:
-            self.fields["allocation"].choices = allocation_choices_sorted
-            self.fields["allocation"].help_text = (
-                "<br/>Select allocations to add selected users to. HX2 allocations are "
-                "not shown here but users can be added to them individually."
-            )
-        else:
-            self.fields["allocation"].widget = forms.HiddenInput()
+        self.fields["allocation"].choices = allocation_choices_sorted
+        self.fields["allocation"].help_text = (
+            "<br/>Select allocations to add selected users to. HX2 allocations are "
+            "not shown here but users can be added to them individually."
+        )
 
 
 class CreditTransactionForm(forms.ModelForm["CreditTransaction"]):

--- a/imperial_coldfront_plugin/views.py
+++ b/imperial_coldfront_plugin/views.py
@@ -442,19 +442,17 @@ class ProjectAddUsersSearchResultsShortnameView(ProjectAddUsersSearchResultsView
                     users_already_in_project.append(ele)
             context["users_already_in_project"] = users_already_in_project
 
+        allocation_form = ProjectAddUsersToAllocationShortnameForm(
+            request.user, project_obj.pk, prefix="allocationform"
+        )
         # The following block of code is used to hide/show the allocation div.
-        if project_obj.allocation_set.filter(
-            status__name__in=["Active", "New", "Renewal Requested"]
-        ).exists():
+        if allocation_form.fields["allocation"].choices:
             div_allocation_class = "placeholder_div_class"
         else:
             div_allocation_class = "d-none"
         context["div_allocation_class"] = div_allocation_class
         ###
 
-        allocation_form = ProjectAddUsersToAllocationShortnameForm(
-            request.user, project_obj.pk, prefix="allocationform"
-        )
         context["pk"] = pk
         context["allocation_form"] = allocation_form
         return render(request, self.template_name, context)


### PR DESCRIPTION
# Description

This PR fixes a subtle issue that prevented users from being added to projects that have only a HX2 allocation. The logic for form hiding was not fully working due to a mismatch in the logic between `ProjectAddUsersToAllocationShortnameForm.__init__` and `ProjectAddUsersSearchResultsShortnameView.post`. This would lead to invalid data being passed to the `project-add-user` view and users being failing to be added to a project.


Fixes # (issue)

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [ ] All tests pass (eg. `python -m pytest`)
- [ ] The documentation builds and looks OK (eg. `python -m sphinx -b html docs docs/build`)
- [ ] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
