### PR TITLE
Consistency updates

### DIFF
--- a/imperial_coldfront_plugin/emails.py
+++ b/imperial_coldfront_plugin/emails.py
@@ -1,13 +1,15 @@
 """Email sending functionality."""
 
 import textwrap
+from dataclasses import dataclass
 from typing import TypedDict
 
 from django.conf import settings
 from django.core.mail import mail_admins, send_mail
 
 
-class Discrepancy(TypedDict):
+@dataclass
+class Discrepancy:
     """Structure for holding discrepancies found during LDAP consistency check."""
 
     group_name: str
@@ -16,38 +18,57 @@ class Discrepancy(TypedDict):
     extra_members: list[str]
 
 
+@dataclass
+class DiscrepancyCheckResult:
+    """Result of an LDAP consistency check."""
+
+    membership_discrepancies: list[Discrepancy]
+    missing_ldap_groups: list[str]
+
+    @property
+    def discrepancies_found(self) -> bool:
+        """Whether any discrepancies were found."""
+        return bool(self.membership_discrepancies or self.missing_ldap_groups)
+
+
 def send_discrepancy_notification(
-    discrepancies: list[Discrepancy], source: str
+    check_result: DiscrepancyCheckResult, source: str
 ) -> None:
     """Send email notification for discrepancies found during the consistency check.
 
     Args:
-        discrepancies: List of discrepancies found.
+        check_result: Discrepancies found.
         source: The source of the discrepancies ("RDF" or "HX2").
     """
     if not settings.ADMINS:
         return
 
     message = (
-        f"The following discrepancies for {source} were detected between "
-        f"Coldfront and AD:\n\n"
+        f"The following discrepancies for {source} allocations were detected between "
+        f"Coldfront and Active Directory:\n\n"
     )
 
-    message += "Membership Discrepancies:\n"
-    for discrepancy in discrepancies:
-        project_name = discrepancy["project_name"]
-        group_id = discrepancy["group_name"]
+    if check_result.membership_discrepancies:
+        message += "Membership Discrepancies:\n"
+    for discrepancy in check_result.membership_discrepancies:
+        project_name = discrepancy.project_name
+        group_id = discrepancy.group_name
         message += f"\n- Project: {project_name} (Group: {group_id})\n"
 
-        if discrepancy["missing_members"]:
+        if discrepancy.missing_members:
             message += "  Missing members (in Coldfront but not in AD):\n"
-            for member in sorted(discrepancy["missing_members"]):
+            for member in sorted(discrepancy.missing_members):
                 message += f"    - {member}\n"
 
-        if discrepancy["extra_members"]:
+        if discrepancy.extra_members:
             message += "  Extra members (in AD but not in Coldfront):\n"
-            for member in sorted(discrepancy["extra_members"]):
+            for member in sorted(discrepancy.extra_members):
                 message += f"    - {member}\n"
+
+    if check_result.missing_ldap_groups:
+        message += f"\n{source} allocations that do not have corresponding AD group:\n"
+        for group in check_result.missing_ldap_groups:
+            message += f"\t- {group}\n"
 
     mail_admins(
         subject=(

--- a/imperial_coldfront_plugin/emails.py
+++ b/imperial_coldfront_plugin/emails.py
@@ -67,7 +67,7 @@ def send_discrepancy_notification(
 
     if check_result.missing_ldap_groups:
         message += f"\n{source} allocations that do not have corresponding AD group:\n"
-        for group in check_result.missing_ldap_groups:
+        for group in sorted(check_result.missing_ldap_groups):
             message += f"\t- {group}\n"
 
     mail_admins(

--- a/imperial_coldfront_plugin/emails.py
+++ b/imperial_coldfront_plugin/emails.py
@@ -72,7 +72,7 @@ def send_discrepancy_notification(
 
     mail_admins(
         subject=(
-            f"LDAP Consistency Check - Discrepancies found for {source} allocations"
+            f"AD Consistency Check - Discrepancies found for {source} allocations"
         ),
         message=message,
     )

--- a/imperial_coldfront_plugin/emails.py
+++ b/imperial_coldfront_plugin/emails.py
@@ -295,3 +295,34 @@ def send_fileset_not_found_notification(shortnames: list[str]) -> None:
         subject=subject,
         message=message,
     )
+
+
+def send_hx2_access_group_discrepancy_notification(discrepancy: Discrepancy) -> None:
+    """Send notification to admins about discrepancies in HX2 access groups.
+
+    Args:
+        discrepancy: The details of the discrepancy found.
+    """
+    if not settings.ADMINS:
+        return
+
+    subject = "Coldfront - HX2 Access Group Membership Discrepancy Detected"
+    message = (
+        "A discrepancy has been detected between the membership of the HX2 access group"
+        f" in Active Directory ({discrepancy.group_name}) and the expected membership "
+        "based on Coldfront data.\n\n"
+    )
+    if discrepancy.missing_members:
+        message += "Missing members (in Coldfront but not in AD):\n"
+        for member in sorted(discrepancy.missing_members):
+            message += f"  - {member}\n"
+
+    if discrepancy.extra_members:
+        message += "\nExtra members (in AD but not in Coldfront):\n"
+        for member in sorted(discrepancy.extra_members):
+            message += f"  - {member}\n"
+
+    mail_admins(
+        subject=subject,
+        message=message,
+    )

--- a/imperial_coldfront_plugin/tasks.py
+++ b/imperial_coldfront_plugin/tasks.py
@@ -27,6 +27,7 @@ from imperial_coldfront_plugin.models import (
 
 from .emails import (
     Discrepancy,
+    DiscrepancyCheckResult,
     QuotaDiscrepancy,
     notify_platforms_to_manually_delete_allocation,
     send_allocation_deletion_notification,
@@ -236,9 +237,10 @@ def create_rdf_allocation(form_data: AllocationFormData, authoriser: str = "") -
 def find_discrepancies_helper(
     allocations: QuerySet[RDFAllocation | HX2Allocation],
     ldap_groups: dict[str, list[str]],
-) -> list[Discrepancy]:
+) -> DiscrepancyCheckResult:
     """Finds discrepancies between LDAP groups and allocation users."""
     discrepancies: list[Discrepancy] = []
+    missing_ldap_groups = []
     for allocation in allocations:
         group_name = allocation.ldap_shortname
 
@@ -247,26 +249,32 @@ def find_discrepancies_helper(
         )
         expected_usernames = [au.user.username for au in active_users]
 
-        actual_members = ldap_groups.get(group_name, [])
+        actual_members = ldap_groups.get(group_name)
+        if actual_members is None:
+            missing_ldap_groups.append(group_name)
+            continue
+
         missing_members = set(expected_usernames) - set(actual_members)
         extra_members = set(actual_members) - set(expected_usernames)
 
         if missing_members or extra_members:
             discrepancies.append(
-                {
-                    "group_name": group_name,
-                    "project_name": allocation.project.title,
-                    "missing_members": list(missing_members),
-                    "extra_members": list(extra_members),
-                }
+                Discrepancy(
+                    group_name=group_name,
+                    project_name=allocation.project.title,
+                    missing_members=list(missing_members),
+                    extra_members=list(extra_members),
+                )
             )
-    return discrepancies
+    return DiscrepancyCheckResult(
+        membership_discrepancies=discrepancies, missing_ldap_groups=missing_ldap_groups
+    )
 
 
-def check_rdf_ldap_consistency() -> list[Discrepancy]:
+def check_rdf_ldap_consistency() -> DiscrepancyCheckResult | None:
     """Check the consistency of LDAP groups with the RDF Active allocations."""
     if not settings.LDAP_ENABLED:
-        return []
+        return None
 
     allocations = RDFAllocation.objects.filter(
         resources__name="RDF Active",
@@ -274,18 +282,18 @@ def check_rdf_ldap_consistency() -> list[Discrepancy]:
     ).distinct()
     ldap_groups = ldap_group_member_search(f"{settings.LDAP_RDF_SHORTNAME_PREFIX}*")
 
-    discrepancies = find_discrepancies_helper(allocations, ldap_groups)
+    check_result = find_discrepancies_helper(allocations, ldap_groups)
 
-    if discrepancies:
-        send_discrepancy_notification(discrepancies, source="RDF")
+    if check_result.discrepancies_found:
+        send_discrepancy_notification(check_result, source="RDF")
 
-    return discrepancies
+    return check_result
 
 
-def check_hx2_ldap_consistency() -> list[Discrepancy]:
+def check_hx2_ldap_consistency() -> DiscrepancyCheckResult | None:
     """Check the consistency of LDAP groups with the HX2 allocations in the database."""
     if not settings.LDAP_ENABLED:
-        return []
+        return None
 
     allocations = HX2Allocation.objects.filter(
         resources__name="HX2",
@@ -293,12 +301,12 @@ def check_hx2_ldap_consistency() -> list[Discrepancy]:
     ).distinct()
     ldap_groups = ldap_group_member_search(f"{settings.LDAP_HX2_SHORTNAME_PREFIX}*")
 
-    discrepancies = find_discrepancies_helper(allocations, ldap_groups)
+    check_result = find_discrepancies_helper(allocations, ldap_groups)
 
-    if discrepancies:
-        send_discrepancy_notification(discrepancies, source="HX2")
+    if check_result.discrepancies_found:
+        send_discrepancy_notification(check_result, source="HX2")
 
-    return discrepancies
+    return check_result
 
 
 def update_quota_usages_task() -> None:

--- a/imperial_coldfront_plugin/tasks.py
+++ b/imperial_coldfront_plugin/tasks.py
@@ -36,6 +36,7 @@ from .emails import (
     send_allocation_removal_warning,
     send_discrepancy_notification,
     send_fileset_not_found_notification,
+    send_hx2_access_group_discrepancy_notification,
     send_quota_discrepancy_notification,
 )
 from .forms import AllocationFormData
@@ -651,3 +652,41 @@ def unlink_expired_allocation_filesets() -> None:
             )
         except Exception:
             logger.exception(f"Error unlinking fileset for allocation {shortname}")
+
+
+def check_hx2_user_group_consistency() -> Discrepancy | None:
+    """Check consistency of user group memberships for HX2 allocations."""
+    if not settings.LDAP_ENABLED:
+        return None
+
+    allocation_group_members = set(
+        AllocationUser.objects.filter(
+            status__name="Active",
+            allocation__resources__name="HX2",
+            allocation__status__name="Active",
+        ).values_list("user__username", flat=True)
+    )
+    search_results = ldap_group_member_search(settings.LDAP_HX2_ACCESS_GROUP_NAME)
+    try:
+        ldap_group_members = set(search_results[settings.LDAP_HX2_ACCESS_GROUP_NAME])
+    except KeyError:
+        raise ValueError(
+            "Unable to find HX2 access group in AD during consistency check."
+        )
+
+    missing_members = allocation_group_members - ldap_group_members
+    extra_members = ldap_group_members - allocation_group_members
+
+    if not (missing_members or extra_members):
+        return None
+
+    check_result = Discrepancy(
+        group_name=settings.LDAP_HX2_ACCESS_GROUP_NAME,
+        project_name="",
+        missing_members=list(allocation_group_members - ldap_group_members),
+        extra_members=list(ldap_group_members - allocation_group_members),
+    )
+
+    send_hx2_access_group_discrepancy_notification(check_result)
+
+    return check_result

--- a/imperial_coldfront_plugin/tasks.py
+++ b/imperial_coldfront_plugin/tasks.py
@@ -674,8 +674,8 @@ def check_hx2_user_group_consistency() -> Discrepancy | None:
             "Unable to find HX2 access group in AD during consistency check."
         )
 
-    missing_members = allocation_group_members - ldap_group_members
-    extra_members = ldap_group_members - allocation_group_members
+    missing_members = list(allocation_group_members - ldap_group_members)
+    extra_members = list(ldap_group_members - allocation_group_members)
 
     if not (missing_members or extra_members):
         return None
@@ -683,8 +683,8 @@ def check_hx2_user_group_consistency() -> Discrepancy | None:
     check_result = Discrepancy(
         group_name=settings.LDAP_HX2_ACCESS_GROUP_NAME,
         project_name="",
-        missing_members=list(allocation_group_members - ldap_group_members),
-        extra_members=list(ldap_group_members - allocation_group_members),
+        missing_members=missing_members,
+        extra_members=extra_members,
     )
 
     send_hx2_access_group_discrepancy_notification(check_result)

--- a/tests/test_emails.py
+++ b/tests/test_emails.py
@@ -193,7 +193,7 @@ def test_notify_platforms_to_manually_delete_allocation():
     assert actual_message == textwrap.dedent(expected_message)
 
 
-def test_send_hx2_accessaccess_group_discrepancy_notification():
+def test_send_hx2_access_group_discrepancy_notification():
     """Test sending discrepancy notification for HX2 access groups."""
     check_result = Discrepancy(
         project_name="",

--- a/tests/test_emails.py
+++ b/tests/test_emails.py
@@ -13,6 +13,7 @@ from imperial_coldfront_plugin.emails import (
     notify_platforms_to_manually_delete_allocation,
     send_discrepancy_notification,
     send_fileset_not_found_notification,
+    send_hx2_access_group_discrepancy_notification,
     send_quota_discrepancy_notification,
 )
 
@@ -190,3 +191,29 @@ def test_notify_platforms_to_manually_delete_allocation():
 
     assert actual_subject == expected_subject
     assert actual_message == textwrap.dedent(expected_message)
+
+
+def test_send_hx2_accessaccess_group_discrepancy_notification():
+    """Test sending discrepancy notification for HX2 access groups."""
+    check_result = Discrepancy(
+        project_name="",
+        group_name="hx2-testgroup",
+        missing_members=["alice"],
+        extra_members=["bob"],
+    )
+
+    expected_body = (
+        "A discrepancy has been detected between the membership of the HX2 access group"
+        " in Active Directory (hx2-testgroup) and the expected membership based on "
+        "Coldfront data.\n\n"
+        "Missing members (in Coldfront but not in AD):\n"
+        "  - alice\n\n"
+        "Extra members (in AD but not in Coldfront):\n"
+        "  - bob\n"
+    )
+    send_hx2_access_group_discrepancy_notification(check_result)
+    (message,) = mail.outbox
+    assert message.subject.endswith(
+        "Coldfront - HX2 Access Group Membership Discrepancy Detected"
+    )
+    assert message.body == expected_body.lstrip()

--- a/tests/test_emails.py
+++ b/tests/test_emails.py
@@ -1,11 +1,15 @@
 """Email tests."""
 
 import textwrap
+from string import Template
 
+import pytest
 from django.core import mail
 from django.test import override_settings
 
 from imperial_coldfront_plugin.emails import (
+    Discrepancy,
+    DiscrepancyCheckResult,
     notify_platforms_to_manually_delete_allocation,
     send_discrepancy_notification,
     send_fileset_not_found_notification,
@@ -13,7 +17,12 @@ from imperial_coldfront_plugin.emails import (
 )
 
 
-@override_settings(ADMINS=[("Name", "admin@email.com")])
+@pytest.fixture(autouse=True)
+def admin_email(settings):
+    """Set up admin email for testing."""
+    settings.ADMINS = [("Name", "admin@email.com")]
+
+
 def test_send_quota_discrepancy_notification():
     """Test the quota discrepancy email."""
     discrepancies = [
@@ -66,7 +75,6 @@ The following discrepancies were detected between Coldfront and GPFS:
     assert actual_message == expected_message
 
 
-@override_settings(ADMINS=[("Name", "admin@email.com")])
 def test_send_fileset_not_found_notification():
     """Test the fileset not found email."""
     shortnames = ["bio-research-01", "physics-dept-lab"]
@@ -91,43 +99,69 @@ The following allocation(s) in Coldfront had no corresponding fileset in GPFS:
     assert actual_message == expected_message
 
 
-@override_settings(ADMINS=[("Name", "admin@email.com")])
-def test_send_discrepancy_notification_rdf():
-    """Test that the discrepancy email references RDF by default."""
-    discrepancies = [
-        {
-            "project_name": "Test Project",
-            "group_name": "rdfdev-testgroup",
-            "missing_members": ["alice"],
-            "extra_members": [],
-        }
-    ]
+message = Template(
+    "The following discrepancies for $source allocations were detected between "
+    "Coldfront and Active Directory:"
+    "\n\n"
+    "$membership_discrepancies_text"
+    "$missing_ldap_groups_text"
+)
 
-    # Default with no source uses RDF:
-    send_discrepancy_notification(discrepancies, source="RDF")
+
+@pytest.mark.parametrize("source", ["RDF", "HX2"])
+def test_send_discrepancy_notification_membership_discrepancies(source: str):
+    """Test email text for group membership discrepancies."""
+    check_result = DiscrepancyCheckResult(
+        membership_discrepancies=[
+            Discrepancy(
+                project_name="Test Project",
+                group_name="rdfdev-testgroup",
+                missing_members=["alice"],
+                extra_members=["bob"],
+            )
+        ],
+        missing_ldap_groups=[],
+    )
+
+    membership_discrepancies_text = (
+        "Membership Discrepancies:\n\n"
+        "- Project: Test Project (Group: rdfdev-testgroup)\n"
+        "  Missing members (in Coldfront but not in AD):\n"
+        "    - alice\n"
+        "  Extra members (in AD but not in Coldfront):\n"
+        "    - bob\n"
+    )
+
+    send_discrepancy_notification(check_result, source=source)
 
     assert len(mail.outbox) == 1
-    assert "RDF" in mail.outbox[0].subject
-    assert "RDF" in mail.outbox[0].body
+    assert mail.outbox[0].body == message.substitute(
+        source=source,
+        membership_discrepancies_text=membership_discrepancies_text,
+        missing_ldap_groups_text="",
+    )
 
 
-@override_settings(ADMINS=[("Name", "admin@email.com")])
-def test_send_discrepancy_notification_hx2():
-    """Test that the discrepancy email references HX2 when source is HX2."""
-    discrepancies = [
-        {
-            "project_name": "Test Project",
-            "group_name": "hx2dev-testgroup",
-            "missing_members": ["alice"],
-            "extra_members": [],
-        }
-    ]
+@pytest.mark.parametrize("source", ["RDF", "HX2"])
+def test_send_discrepancy_notification_missing_ldap_groups(source: str):
+    """Test that the discrepancy email includes missing LDAP groups."""
+    check_result = DiscrepancyCheckResult(
+        membership_discrepancies=[],
+        missing_ldap_groups=["rdfdev-testgroup"],
+    )
+    missing_ldap_groups_text = (
+        f"\n{source} allocations that do not have corresponding AD group:\n"
+        "\t- rdfdev-testgroup\n"
+    )
 
-    send_discrepancy_notification(discrepancies, source="HX2")
+    send_discrepancy_notification(check_result, source=source)
 
     assert len(mail.outbox) == 1
-    assert "HX2" in mail.outbox[0].subject
-    assert "HX2" in mail.outbox[0].body
+    assert mail.outbox[0].body == message.substitute(
+        source=source,
+        membership_discrepancies_text="",
+        missing_ldap_groups_text=missing_ldap_groups_text,
+    )
 
 
 @override_settings(RCS_NOTIFICATION_EMAILS=[("Name", "rcs@email.com")])

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -540,6 +540,22 @@ class TestCheckRDFLdapConsistency:
 
         notify_mock.assert_called_once_with(result, source="RDF")
 
+    def test_missing_group(
+        self,
+        rdf_allocation,
+        rdf_allocation_user,
+        ldap_group_search_mock,
+        notify_mock,
+        rdf_allocation_ldap_name,
+    ):
+        """Test when allocation does not have corresponding AD group."""
+        ldap_group_search_mock.return_value = {}
+
+        result = check_rdf_ldap_consistency()
+
+        assert result == DiscrepancyCheckResult([], [rdf_allocation_ldap_name])
+        notify_mock.assert_called_once_with(result, source="RDF")
+
 
 class TestCheckHX2LdapConsistency:
     """Tests for check_hx2_ldap_consistency task."""
@@ -607,6 +623,21 @@ class TestCheckHX2LdapConsistency:
         assert not discrepancy.missing_members
         assert discrepancy.extra_members == [extra_user]
 
+        notify_mock.assert_called_once_with(result, source="HX2")
+
+    def test_missing_group(
+        self,
+        hx2_allocation,
+        hx2_allocation_user,
+        ldap_group_search_mock,
+        notify_mock,
+    ):
+        """Test when allocation does not have corresponding AD group."""
+        ldap_group_search_mock.return_value = {}
+
+        result = check_hx2_ldap_consistency()
+
+        assert result == DiscrepancyCheckResult([], [hx2_allocation.ldap_shortname])
         notify_mock.assert_called_once_with(result, source="HX2")
 
 

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -14,13 +14,14 @@ from coldfront.core.resource.models import Resource
 from django.conf import settings
 from django.utils import timezone
 
-from imperial_coldfront_plugin.emails import DiscrepancyCheckResult
+from imperial_coldfront_plugin.emails import Discrepancy, DiscrepancyCheckResult
 from imperial_coldfront_plugin.forms import RDFAllocationForm
 from imperial_coldfront_plugin.gid import get_new_gid
 from imperial_coldfront_plugin.gpfs_client import FilesetPathInfo
 from imperial_coldfront_plugin.models import CreditTransaction
 from imperial_coldfront_plugin.tasks import (
     check_hx2_ldap_consistency,
+    check_hx2_user_group_consistency,
     check_rdf_allocation_expiry_notifications,
     check_rdf_ldap_consistency,
     create_rdf_allocation,
@@ -1274,3 +1275,109 @@ class TestUpdateQuotaUsagesTask:
 
         files_quota_usage.refresh_from_db()
         assert files_quota_usage.value == 1234
+
+
+class TestCheckHX2UserGroupConsistency:
+    """Tests for check_hx2_user_group_consistency task."""
+
+    @pytest.fixture(autouse=True)
+    def notify_mock(self, mocker):
+        """Fixture to mock the notify function."""
+        return mocker.patch(
+            "imperial_coldfront_plugin.tasks."
+            "send_hx2_access_group_discrepancy_notification"
+        )
+
+    def test_no_discrepancies(
+        self,
+        hx2_allocation,
+        hx2_allocation_user,
+        ldap_group_search_mock,
+        notify_mock,
+        settings,
+    ):
+        """Test when everything is in sync between Coldfront and AD."""
+        username = hx2_allocation_user.user.username
+        ldap_name = settings.LDAP_HX2_ACCESS_GROUP_NAME
+        ldap_group_search_mock.return_value = {ldap_name: [username]}
+
+        result = check_hx2_user_group_consistency()
+        assert result is None
+        notify_mock.assert_not_called()
+
+    def test_missing_members(
+        self,
+        hx2_allocation,
+        hx2_allocation_user,
+        ldap_group_search_mock,
+        notify_mock,
+        settings,
+    ):
+        """Test when a user is missing from AD group."""
+        username = hx2_allocation_user.user.username
+        ldap_name = settings.LDAP_HX2_ACCESS_GROUP_NAME
+        ldap_group_search_mock.return_value = {ldap_name: []}
+
+        discrepancy = check_hx2_user_group_consistency()
+        assert discrepancy == Discrepancy(
+            group_name=ldap_name,
+            project_name="",
+            missing_members=[username],
+            extra_members=[],
+        )
+
+        notify_mock.assert_called_once_with(discrepancy)
+
+    def test_extra_members(
+        self,
+        hx2_allocation,
+        hx2_allocation_user,
+        ldap_group_search_mock,
+        notify_mock,
+        settings,
+    ):
+        """Test when there are extra users in AD group."""
+        username = hx2_allocation_user.user.username
+        extra_user = "extra_user"
+        ldap_name = settings.LDAP_HX2_ACCESS_GROUP_NAME
+        ldap_group_search_mock.return_value = {ldap_name: [username, extra_user]}
+
+        discrepancy = check_hx2_user_group_consistency()
+        assert discrepancy == Discrepancy(
+            group_name=ldap_name,
+            project_name="",
+            missing_members=[],
+            extra_members=[extra_user],
+        )
+
+        notify_mock.assert_called_once_with(discrepancy)
+
+    def test_ldap_disabled(
+        self,
+        hx2_allocation,
+        hx2_allocation_user,
+        ldap_group_search_mock,
+        notify_mock,
+        settings,
+    ):
+        """Test when a user is missing from AD group."""
+        settings.LDAP_ENABLED = False
+
+        # setup a potential discrepancy that should not be reported
+        ldap_name = settings.LDAP_HX2_ACCESS_GROUP_NAME
+        ldap_group_search_mock.return_value = {ldap_name: []}
+
+        discrepancy = check_hx2_user_group_consistency()
+
+        assert discrepancy is None
+        notify_mock.assert_not_called()
+
+    def test_missing_ldap_group(self, ldap_group_search_mock, notify_mock, db):
+        """Test when the LDAP group is missing."""
+        ldap_group_search_mock.return_value = {}
+
+        with pytest.raises(
+            ValueError,
+            match=r"Unable to find HX2 access group in AD during consistency check.",
+        ):
+            check_hx2_user_group_consistency()

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -14,6 +14,7 @@ from coldfront.core.resource.models import Resource
 from django.conf import settings
 from django.utils import timezone
 
+from imperial_coldfront_plugin.emails import DiscrepancyCheckResult
 from imperial_coldfront_plugin.forms import RDFAllocationForm
 from imperial_coldfront_plugin.gid import get_new_gid
 from imperial_coldfront_plugin.gpfs_client import FilesetPathInfo
@@ -485,7 +486,7 @@ class TestCheckRDFLdapConsistency:
 
         result = check_rdf_ldap_consistency()
 
-        assert result == []
+        assert result == DiscrepancyCheckResult([], [])
         notify_mock.assert_not_called()
 
     def test_missing_members(
@@ -501,15 +502,16 @@ class TestCheckRDFLdapConsistency:
         ldap_group_search_mock.return_value = {rdf_allocation_ldap_name: []}
 
         result = check_rdf_ldap_consistency()
+        membership_discrepancies = result.membership_discrepancies
 
-        assert len(result) == 1
-        discrepancy = result[0]
-        assert discrepancy["group_name"] == rdf_allocation_ldap_name
-        assert discrepancy["project_name"] == rdf_allocation.project.title
-        assert username in discrepancy["missing_members"]
-        assert not discrepancy["extra_members"]
+        assert len(membership_discrepancies) == 1
+        discrepancy = membership_discrepancies[0]
+        assert discrepancy.group_name == rdf_allocation_ldap_name
+        assert discrepancy.project_name == rdf_allocation.project.title
+        assert discrepancy.missing_members == [username]
+        assert not discrepancy.extra_members
 
-        notify_mock.assert_called_once()
+        notify_mock.assert_called_once_with(result, source="RDF")
 
     def test_extra_members(
         self,
@@ -527,14 +529,15 @@ class TestCheckRDFLdapConsistency:
         }
 
         result = check_rdf_ldap_consistency()
+        membership_discrepancies = result.membership_discrepancies
 
-        assert len(result) == 1
-        discrepancy = result[0]
-        assert discrepancy["group_name"] == rdf_allocation_ldap_name
-        assert not discrepancy["missing_members"]
-        assert extra_user in discrepancy["extra_members"]
+        assert len(membership_discrepancies) == 1
+        discrepancy = membership_discrepancies[0]
+        assert discrepancy.group_name == rdf_allocation_ldap_name
+        assert not discrepancy.missing_members
+        assert discrepancy.extra_members == [extra_user]
 
-        notify_mock.assert_called_once()
+        notify_mock.assert_called_once_with(result, source="RDF")
 
 
 class TestCheckHX2LdapConsistency:
@@ -554,7 +557,7 @@ class TestCheckHX2LdapConsistency:
 
         result = check_hx2_ldap_consistency()
 
-        assert result == []
+        assert result == DiscrepancyCheckResult([], [])
         notify_mock.assert_not_called()
 
     def test_missing_members(
@@ -570,13 +573,14 @@ class TestCheckHX2LdapConsistency:
         ldap_group_search_mock.return_value = {ldap_name: []}
 
         result = check_hx2_ldap_consistency()
+        membership_discrepancies = result.membership_discrepancies
 
-        assert len(result) == 1
-        discrepancy = result[0]
-        assert discrepancy["group_name"] == ldap_name
-        assert discrepancy["project_name"] == hx2_allocation.project.title
-        assert username in discrepancy["missing_members"]
-        assert not discrepancy["extra_members"]
+        assert len(membership_discrepancies) == 1
+        discrepancy = membership_discrepancies[0]
+        assert discrepancy.group_name == ldap_name
+        assert discrepancy.project_name == hx2_allocation.project.title
+        assert discrepancy.missing_members == [username]
+        assert not discrepancy.extra_members
 
         notify_mock.assert_called_once_with(result, source="HX2")
 
@@ -594,12 +598,13 @@ class TestCheckHX2LdapConsistency:
         ldap_group_search_mock.return_value = {ldap_name: [username, extra_user]}
 
         result = check_hx2_ldap_consistency()
+        membership_discrepancies = result.membership_discrepancies
 
-        assert len(result) == 1
-        discrepancy = result[0]
-        assert discrepancy["group_name"] == ldap_name
-        assert not discrepancy["missing_members"]
-        assert extra_user in discrepancy["extra_members"]
+        assert len(membership_discrepancies) == 1
+        discrepancy = membership_discrepancies[0]
+        assert discrepancy.group_name == ldap_name
+        assert not discrepancy.missing_members
+        assert discrepancy.extra_members == [extra_user]
 
         notify_mock.assert_called_once_with(result, source="HX2")
 


### PR DESCRIPTION
# Description

In preparation for a disaster recovery run through I've taken a quick pass at the consistency checks and notifications that we've implemented. Changes:
- More explicitly report when expected groups in LDAP/AD are missing (these were previously reported as groups with missing members).
- Add a consistency check of the overarching HX2 access AD group.
- Minor refactor of data structures.

Fixes # (issue)

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [ ] All tests pass (eg. `python -m pytest`)
- [ ] The documentation builds and looks OK (eg. `python -m sphinx -b html docs docs/build`)
- [ ] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
