### PR TITLE
Restrict the credit transactions and balance to project managers

### DIFF
--- a/imperial_coldfront_plugin/policy.py
+++ b/imperial_coldfront_plugin/policy.py
@@ -178,7 +178,7 @@ def check_project_manager_or_pi_or_superuser(project: Project, user: "User") -> 
       user: The user to check.
 
     Raises:
-      PermissionDenied: If the user is neither the project manager nor a superuser.
+      PermissionDenied: If the user is neither the project owner (PI), a manager, nor a superuser.
     """
     is_manager = project.projectuser_set.filter(
         user=user,

--- a/imperial_coldfront_plugin/policy.py
+++ b/imperial_coldfront_plugin/policy.py
@@ -168,3 +168,23 @@ def check_project_pi_or_superuser(project: Project, user: "User") -> None:
     """
     if not (user.is_superuser or user == project.pi):
         raise PermissionDenied
+
+
+def check_project_manager_or_pi_or_superuser(project: Project, user: "User") -> None:
+    """Check if the user is the owner of the project, a manager, or a superuser.
+
+    Args:
+      project: The project to check against.
+      user: The user to check.
+
+    Raises:
+      PermissionDenied: If the user is neither the project manager nor a superuser.
+    """
+    is_manager = project.projectuser_set.filter(
+        user=user,
+        role__name="Manager",
+        status__name="Active",
+    ).exists()
+
+    if not (user.is_superuser or is_manager or user == project.pi):
+        raise PermissionDenied

--- a/imperial_coldfront_plugin/policy.py
+++ b/imperial_coldfront_plugin/policy.py
@@ -186,5 +186,5 @@ def check_project_manager_or_pi_or_superuser(project: Project, user: "User") -> 
         status__name="Active",
     ).exists()
 
-    if not (user.is_superuser or is_manager or user == project.pi):
+    if not (user.is_superuser or user == project.pi or is_manager):
         raise PermissionDenied

--- a/imperial_coldfront_plugin/policy.py
+++ b/imperial_coldfront_plugin/policy.py
@@ -179,7 +179,7 @@ def check_project_manager_or_pi_or_superuser(project: Project, user: "User") -> 
 
     Raises:
       PermissionDenied: If the user is neither the project owner (PI), a manager, nor a superuser.
-    """
+    """  # noqa: E501
     is_manager = project.projectuser_set.filter(
         user=user,
         role__name="Manager",

--- a/imperial_coldfront_plugin/templates/imperial_coldfront_plugin/overrides/project_detail.html
+++ b/imperial_coldfront_plugin/templates/imperial_coldfront_plugin/overrides/project_detail.html
@@ -5,6 +5,7 @@
 {% load projects %}
 {% load common_tags %}
 
+
 {% if is_allowed_to_update_project and project.needs_review%}
   <div class="alert alert-warning">
     You need to review this project. <a href="{% url 'project-review' project.pk %}">Review Project</a>
@@ -26,7 +27,8 @@
 </div>
 
 {% if settings.SHOW_CREDIT_BALANCE %}
-  {% if request.user == project.pi or request.user.is_superuser %}
+{% is_project_manager project request.user as can_view_credit %}
+  {% if request.user == project.pi or request.user.is_superuser or can_view_credit %}
 <!-- Start Credit Balance Display -->
 <div class="card mb-3 bg-light border-primary" id="credit-balance-card">
   <div class="card-body">

--- a/imperial_coldfront_plugin/templates/imperial_coldfront_plugin/project_credit_transactions.html
+++ b/imperial_coldfront_plugin/templates/imperial_coldfront_plugin/project_credit_transactions.html
@@ -13,7 +13,7 @@
       </div>
       <div class="card-body p-0">
         <div class="table-responsive">
-          <table class="table table-striped table-hover mb-0">
+          <table class="table table-striped table-hover mb-0" id="transactions-table">
             <thead class="thead-light">
               <tr>
                 <th scope="col">Date</th>

--- a/imperial_coldfront_plugin/templatetags/projects.py
+++ b/imperial_coldfront_plugin/templatetags/projects.py
@@ -2,7 +2,7 @@
 
 from typing import TYPE_CHECKING
 
-from coldfront.core.project.models import ProjectUser
+from coldfront.core.project.models import Project, ProjectUser
 from django import template
 from django.db.models.query import QuerySet
 
@@ -87,7 +87,7 @@ def get_project_credit_balance(project: ICLProject) -> int:
 
 
 @register.simple_tag
-def is_project_manager(project: ICLProject, user: "User") -> bool:
+def is_project_manager(project: Project, user: "User") -> bool:
     """Check if the user is a manager of the project.
 
     Args:

--- a/imperial_coldfront_plugin/templatetags/projects.py
+++ b/imperial_coldfront_plugin/templatetags/projects.py
@@ -84,3 +84,22 @@ def get_project_credit_balance(project: ICLProject) -> int:
     """
     balance = calculate_credit_balance(project)
     return balance if balance is not None else 0
+
+
+@register.simple_tag
+def is_project_manager(project: ICLProject, user: "User") -> bool:
+    """Check if the user is a manager of the project.
+
+    Args:
+      project: The project to check against.
+      user: The user to check.
+
+    Returns:
+        True if the user is a manager of the project, False otherwise.
+    """
+    return ProjectUser.objects.filter(
+        project=project,
+        user=user,
+        role__name="Manager",
+        status__name="Active",
+    ).exists()

--- a/imperial_coldfront_plugin/views.py
+++ b/imperial_coldfront_plugin/views.py
@@ -46,6 +46,7 @@ from .forms import (
 from .microsoft_graph_client import get_graph_api_client
 from .models import CreditTransaction, HX2Allocation, ICLProject
 from .policy import (
+    check_project_manager_or_pi_or_superuser,
     check_project_pi_or_superuser,
     user_eligible_for_hpc_access,
     user_eligible_to_be_pi,
@@ -498,7 +499,7 @@ def project_credit_transactions(
 ) -> HttpResponse:
     """Display all credit transactions for a project with running balance."""
     project = get_object_or_404(Project, pk=pk)
-    check_project_pi_or_superuser(project, request.user)
+    check_project_manager_or_pi_or_superuser(project, request.user)
 
     transactions = CreditTransaction.objects.filter(project=project).order_by(
         "timestamp", "id"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -604,3 +604,32 @@ def rdf_or_hx2_allocation(request):
 def rdf_or_hx2_allocation_user(request):
     """Fixture to provide an AllocationUser for either an RDF or HX2 allocation."""
     return request.getfixturevalue(request.param)
+
+
+@pytest.fixture
+def project_pi(project):
+    """Return the PI of the project."""
+    return project.pi
+
+
+@pytest.fixture
+def project_manager(
+    project, user_factory, project_user_active_status, project_user_role_manager
+):
+    """Return a user with the manager role in the project."""
+    from coldfront.core.project.models import ProjectUser
+
+    manager = user_factory()
+    ProjectUser.objects.create(
+        project=project,
+        user=manager,
+        status=project_user_active_status,
+        role=project_user_role_manager,
+    )
+    return manager
+
+
+@pytest.fixture(params=["project_pi", "superuser", "project_manager"])
+def manager_pi_or_superuser(request):
+    """Fixture providing a PI, superuser, or manager of the project."""
+    return request.getfixturevalue(request.param)

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1193,10 +1193,10 @@ class TestProjectDetailView:
         soup = BeautifulSoup(response.content, "html.parser")
         assert not soup.find("div", class_="card", id="credit-balance-card")
 
-    def test_credit_balance_only_visible_to_pi_and_superuser(
-        self, rf, project, settings, user_factory, superuser
+    def test_credit_balance_only_visible_to_pi_superuser_and_manager(
+        self, rf, project, settings, user_factory, superuser, project_user_role_manager
     ):
-        """Ensure credit balance section is only rendered for the PI and superusers."""
+        """Ensure credit balance section is only rendered for the PI, superusers, and managers."""  # noqa: E501
         settings.SHOW_CREDIT_BALANCE = True
         tmpl = "imperial_coldfront_plugin/overrides/project_detail.html"
 
@@ -1220,6 +1220,14 @@ class TestProjectDetailView:
 
         # superuser should see the section
         request.user = superuser
+        response = render(
+            request, tmpl, context={"project": project, "settings": settings}
+        )
+        soup = BeautifulSoup(response.content, "html.parser")
+        assert soup.find("div", class_="card", id="credit-balance-card")
+
+        # manager should see the section
+        request.user = project_user_role_manager.user
         response = render(
             request, tmpl, context={"project": project, "settings": settings}
         )
@@ -1265,6 +1273,16 @@ class TestProjectCreditTransactionsView(LoginRequiredMixin):
         """Test that superuser can access the transactions page."""
         url = self._get_url(project.pk)
         response = superuser_client.get(url)
+        assert response.status_code == 200
+
+    def test_manager_can_access(
+        self, project, project_user_role_manager, auth_client_factory
+    ):
+        """Test that project managers can access the transactions page."""
+        manager = project_user_role_manager.user
+        client = auth_client_factory(manager)
+        url = self._get_url(project.pk)
+        response = client.get(url)
         assert response.status_code == 200
 
     def test_transactions_displayed_with_total(self, superuser_client, project):

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1241,30 +1241,6 @@ class TestProjectCreditTransactionsView(LoginRequiredMixin):
             kwargs={"pk": pk},
         )
 
-    def test_permission_denied_non_member(
-        self, user_factory, auth_client_factory, project
-    ):
-        """Test that non-project members cannot access the view."""
-        non_member = user_factory()
-        client = auth_client_factory(non_member)
-
-        url = self._get_url(project.pk)
-        response = client.get(url)
-        assert response.status_code == 403
-
-    def test_pi_can_access(self, client, project):
-        """Test that PI can access the transactions page."""
-        client.force_login(project.pi)
-        url = self._get_url(project.pk)
-        response = client.get(url)
-        assert response.status_code == 200
-
-    def test_superuser_can_access(self, superuser_client, project):
-        """Test that superuser can access the transactions page."""
-        url = self._get_url(project.pk)
-        response = superuser_client.get(url)
-        assert response.status_code == 200
-
     def test_transactions_displayed_with_total(self, superuser_client, project):
         """Test that transactions are sorted and running balance is calculated."""
         settings.SHOW_CREDIT_BALANCE = True
@@ -1333,26 +1309,31 @@ class TestProjectCreditTransactionsView(LoginRequiredMixin):
         assert rows[0].find("td", text="Storage")
         assert rows[1].find("td", text="Storage")
 
-    def test_managers_can_see_transactions(
+    def test_pi_superuser_and_manager_can_access(
         self,
-        user_factory,
-        auth_client_factory,
+        client,
         project,
-        project_user_active_status,
-        project_user_role_manager,
+        manager_pi_or_superuser,
+        user_factory,
+        settings,
+        auth_client_factory,
     ):
-        """Test that project managers can access the transactions page."""
-        manager = user_factory()
-        ProjectUser.objects.create(
-            project=project,
-            user=manager,
-            status=project_user_active_status,
-            role=project_user_role_manager,
-        )
-        client = auth_client_factory(manager)
+        """Test that the PI, superusers, and managers can access the view."""
+        settings.SHOW_CREDIT_BALANCE = True
         url = self._get_url(project.pk)
+
+        # non-privileged user should get 403
+        regular_user = user_factory()
+        client = auth_client_factory(regular_user)
         response = client.get(url)
+        assert response.status_code == 403
+
+        # privileged user should see the transactions table
+        privileged_client = auth_client_factory(manager_pi_or_superuser)
+        response = privileged_client.get(url)
         assert response.status_code == 200
+        soup = BeautifulSoup(response.content, "html.parser")
+        assert soup.find("table", id="transactions-table")
 
 
 class TestAllocationDetailBanners:

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1199,16 +1199,15 @@ class TestProjectDetailView:
         project,
         settings,
         user_factory,
-        superuser,
-        project_user_role_manager,
-        project_user_active_status,
+        manager_pi_or_superuser,
     ):
         """Ensure credit balance section is only rendered for the PI, superusers, and managers."""  # noqa: E501
         settings.SHOW_CREDIT_BALANCE = True
         tmpl = "imperial_coldfront_plugin/overrides/project_detail.html"
 
-        # non-member should not see the section
         request = rf.get("/")
+
+        # non-member should not see the section
         request.user = user_factory()
         response = render(
             request, tmpl, context={"project": project, "settings": settings}
@@ -1217,31 +1216,8 @@ class TestProjectDetailView:
         soup = BeautifulSoup(response.content, "html.parser")
         assert not soup.find("div", class_="card", id="credit-balance-card")
 
-        # project PI should see the section
-        request.user = project.pi
-        response = render(
-            request, tmpl, context={"project": project, "settings": settings}
-        )
-        soup = BeautifulSoup(response.content, "html.parser")
-        assert soup.find("div", class_="card", id="credit-balance-card")
-
-        # superuser should see the section
-        request.user = superuser
-        response = render(
-            request, tmpl, context={"project": project, "settings": settings}
-        )
-        soup = BeautifulSoup(response.content, "html.parser")
-        assert soup.find("div", class_="card", id="credit-balance-card")
-
-        # manager should see the section
-        manager = user_factory()
-        ProjectUser.objects.create(
-            project=project,
-            user=manager,
-            status=project_user_active_status,
-            role=project_user_role_manager,
-        )
-        request.user = manager
+        # privileged user should see the section
+        request.user = manager_pi_or_superuser
         response = render(
             request, tmpl, context={"project": project, "settings": settings}
         )

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1194,7 +1194,14 @@ class TestProjectDetailView:
         assert not soup.find("div", class_="card", id="credit-balance-card")
 
     def test_credit_balance_only_visible_to_pi_superuser_and_manager(
-        self, rf, project, settings, user_factory, superuser, project_user_role_manager
+        self,
+        rf,
+        project,
+        settings,
+        user_factory,
+        superuser,
+        project_user_role_manager,
+        project_user_active_status,
     ):
         """Ensure credit balance section is only rendered for the PI, superusers, and managers."""  # noqa: E501
         settings.SHOW_CREDIT_BALANCE = True
@@ -1227,7 +1234,14 @@ class TestProjectDetailView:
         assert soup.find("div", class_="card", id="credit-balance-card")
 
         # manager should see the section
-        request.user = project_user_role_manager.user
+        manager = user_factory()
+        ProjectUser.objects.create(
+            project=project,
+            user=manager,
+            status=project_user_active_status,
+            role=project_user_role_manager,
+        )
+        request.user = manager
         response = render(
             request, tmpl, context={"project": project, "settings": settings}
         )
@@ -1273,16 +1287,6 @@ class TestProjectCreditTransactionsView(LoginRequiredMixin):
         """Test that superuser can access the transactions page."""
         url = self._get_url(project.pk)
         response = superuser_client.get(url)
-        assert response.status_code == 200
-
-    def test_manager_can_access(
-        self, project, project_user_role_manager, auth_client_factory
-    ):
-        """Test that project managers can access the transactions page."""
-        manager = project_user_role_manager.user
-        client = auth_client_factory(manager)
-        url = self._get_url(project.pk)
-        response = client.get(url)
         assert response.status_code == 200
 
     def test_transactions_displayed_with_total(self, superuser_client, project):
@@ -1352,6 +1356,27 @@ class TestProjectCreditTransactionsView(LoginRequiredMixin):
         assert rows[1].find("span", class_="text-danger")
         assert rows[0].find("td", text="Storage")
         assert rows[1].find("td", text="Storage")
+
+    def test_managers_can_see_transactions(
+        self,
+        user_factory,
+        auth_client_factory,
+        project,
+        project_user_active_status,
+        project_user_role_manager,
+    ):
+        """Test that project managers can access the transactions page."""
+        manager = user_factory()
+        ProjectUser.objects.create(
+            project=project,
+            user=manager,
+            status=project_user_active_status,
+            role=project_user_role_manager,
+        )
+        client = auth_client_factory(manager)
+        url = self._get_url(project.pk)
+        response = client.get(url)
+        assert response.status_code == 200
 
 
 class TestAllocationDetailBanners:


### PR DESCRIPTION
# Description
I have added a new permission for project managers to be able to access the project credit transactions view. 

Fixes #400 

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [ ] All tests pass (eg. `python -m pytest`)
- [ ] The documentation builds and looks OK (eg. `python -m sphinx -b html docs docs/build`)
- [ ] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
