### PR TITLE
Include imp flag for allocation status change emails

### DIFF
--- a/imperial_coldfront_plugin/emails.py
+++ b/imperial_coldfront_plugin/emails.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 from typing import TypedDict
 
 from django.conf import settings
-from django.core.mail import EmailMessage, mail_admins
+from django.core.mail import EmailMessage, mail_admins, send_mail
 
 HIGH_PRIORITY_EMAIL_HEADERS = {
     "Importance": "high",

--- a/imperial_coldfront_plugin/emails.py
+++ b/imperial_coldfront_plugin/emails.py
@@ -103,7 +103,7 @@ Please take necessary action to renew or backup your data.
 """
     EmailMessage(
         subject=subject,
-        body=body,
+        body=textwrap.dedent(body),
         from_email=settings.DEFAULT_FROM_EMAIL,
         to=[project_owner_email],
         headers=HIGH_PRIORITY_EMAIL_HEADERS,
@@ -132,7 +132,7 @@ Data removal will occur soon if no action is taken.
 """
     EmailMessage(
         subject=subject,
-        body=body,
+        body=textwrap.dedent(body),
         from_email=settings.DEFAULT_FROM_EMAIL,
         to=[project_owner_email],
         headers=HIGH_PRIORITY_EMAIL_HEADERS,
@@ -159,7 +159,7 @@ Data will be permanently deleted soon.
 """
     EmailMessage(
         subject=subject,
-        body=body,
+        body=textwrap.dedent(body),
         from_email=settings.DEFAULT_FROM_EMAIL,
         to=[project_owner_email],
         headers=HIGH_PRIORITY_EMAIL_HEADERS,
@@ -185,7 +185,7 @@ All associated data has been permanently removed.
 """
     EmailMessage(
         subject=subject,
-        body=body,
+        body=textwrap.dedent(body),
         from_email=settings.DEFAULT_FROM_EMAIL,
         to=[project_owner_email],
         headers=HIGH_PRIORITY_EMAIL_HEADERS,

--- a/imperial_coldfront_plugin/emails.py
+++ b/imperial_coldfront_plugin/emails.py
@@ -3,7 +3,13 @@
 from typing import TypedDict
 
 from django.conf import settings
-from django.core.mail import mail_admins, send_mail
+from django.core.mail import EmailMessage, mail_admins
+
+HIGH_PRIORITY_EMAIL_HEADERS = {
+    "Importance": "high",
+    "X-Priority": "2",
+    "X-MSMail-Priority": "High",
+}
 
 
 class Discrepancy(TypedDict):
@@ -67,18 +73,19 @@ def send_allocation_expiry_warning(
         days_until_expiry: Number of days until the allocation expires.
     """
     subject = f"RDF Allocation Expiry Warning - {days_until_expiry} days remaining"
-    message = f"""
+    body = f"""
 Your RDF allocation {allocation_shortname} will expire in {days_until_expiry} days.
 
 Please take necessary action to renew or backup your data.
 
 """
-    send_mail(
+    EmailMessage(
         subject=subject,
-        message=message,
+        body=body,
         from_email=settings.DEFAULT_FROM_EMAIL,
-        recipient_list=[project_owner_email],
-    )
+        to=[project_owner_email],
+        headers=HIGH_PRIORITY_EMAIL_HEADERS,
+    ).send()
 
 
 def send_allocation_removal_warning(
@@ -94,19 +101,20 @@ def send_allocation_removal_warning(
     subject = (
         f"RDF Allocation Removal Warning - Expired {abs(days_since_expiry)} days ago"
     )
-    message = f"""
+    body = f"""
 Your RDF allocation {allocation_shortname} expired {abs(days_since_expiry)} days ago.
 
 Data removal will occur soon if no action is taken.
 
 [Placeholder text for removal warning]
 """
-    send_mail(
+    EmailMessage(
         subject=subject,
-        message=message,
+        body=body,
         from_email=settings.DEFAULT_FROM_EMAIL,
-        recipient_list=[project_owner_email],
-    )
+        to=[project_owner_email],
+        headers=HIGH_PRIORITY_EMAIL_HEADERS,
+    ).send()
 
 
 def send_allocation_deletion_warning(
@@ -120,19 +128,20 @@ def send_allocation_deletion_warning(
         days_since_expiry: Number of days since the allocation expired.
     """
     subject = "RDF Allocation Deletion Warning - Final Notice"
-    message = f"""
+    body = f"""
 Your RDF allocation {allocation_shortname} expired {abs(days_since_expiry)} days ago.
 
 Data will be permanently deleted soon.
 
 [Placeholder text for deletion warning]
 """
-    send_mail(
+    EmailMessage(
         subject=subject,
-        message=message,
+        body=body,
         from_email=settings.DEFAULT_FROM_EMAIL,
-        recipient_list=[project_owner_email],
-    )
+        to=[project_owner_email],
+        headers=HIGH_PRIORITY_EMAIL_HEADERS,
+    ).send()
 
 
 def send_allocation_deletion_notification(
@@ -145,19 +154,20 @@ def send_allocation_deletion_notification(
         project_owner_email: Email address of the project owner.
     """
     subject = "RDF Allocation Deleted"
-    message = f"""
+    body = f"""
 Your RDF allocation {allocation_shortname} has been deleted.
 
 All associated data has been permanently removed.
 
 [Placeholder text for deletion notification]
 """
-    send_mail(
+    EmailMessage(
         subject=subject,
-        message=message,
+        body=body,
         from_email=settings.DEFAULT_FROM_EMAIL,
-        recipient_list=[project_owner_email],
-    )
+        to=[project_owner_email],
+        headers=HIGH_PRIORITY_EMAIL_HEADERS,
+    ).send()
 
 
 class QuotaDiscrepancy(TypedDict):

--- a/tests/test_emails.py
+++ b/tests/test_emails.py
@@ -261,7 +261,7 @@ def test_send_hx2_access_group_discrepancy_notification():
 )
 @override_settings(DEFAULT_FROM_EMAIL="noreply@email.com")
 def test_allocation_status_emails_have_imp_flag(send_email, arguments):
-    """Test that allocation status emails are sent with the imp flag."""
+    """Test that allocation status emails are sent with the importance flag."""
     send_email(**arguments)
 
     assert len(mail.outbox) == 1

--- a/tests/test_emails.py
+++ b/tests/test_emails.py
@@ -1,9 +1,14 @@
 """Email tests."""
 
+import pytest
 from django.core import mail
 from django.test import override_settings
 
 from imperial_coldfront_plugin.emails import (
+    send_allocation_deletion_notification,
+    send_allocation_deletion_warning,
+    send_allocation_expiry_warning,
+    send_allocation_removal_warning,
     send_discrepancy_notification,
     send_fileset_not_found_notification,
     send_quota_discrepancy_notification,
@@ -125,3 +130,52 @@ def test_send_discrepancy_notification_hx2():
     assert len(mail.outbox) == 1
     assert "HX2" in mail.outbox[0].subject
     assert "HX2" in mail.outbox[0].body
+
+
+@pytest.mark.parametrize(
+    "send_email, arguments",
+    [
+        (
+            send_allocation_expiry_warning,
+            {
+                "allocation_shortname": "bio-research-01",
+                "project_owner_email": "owner@email.com",
+                "days_until_expiry": 7,
+            },
+        ),
+        (
+            send_allocation_removal_warning,
+            {
+                "allocation_shortname": "bio-research-01",
+                "project_owner_email": "owner@email.com",
+                "days_since_expiry": 8,
+            },
+        ),
+        (
+            send_allocation_deletion_warning,
+            {
+                "allocation_shortname": "bio-research-01",
+                "project_owner_email": "owner@email.com",
+                "days_since_expiry": 10,
+            },
+        ),
+        (
+            send_allocation_deletion_notification,
+            {
+                "allocation_shortname": "bio-research-01",
+                "project_owner_email": "owner@email.com",
+            },
+        ),
+    ],
+)
+@override_settings(DEFAULT_FROM_EMAIL="noreply@email.com")
+def test_allocation_status_emails_have_imp_flag(send_email, arguments):
+    """Test that allocation status emails are sent with the imp flag."""
+    send_email(**arguments)
+
+    assert len(mail.outbox) == 1
+    headers = mail.outbox[0].extra_headers
+
+    assert headers["Importance"] == "high"
+    assert headers["X-Priority"] == "2"
+    assert headers["X-MSMail-Priority"] == "High"

--- a/tests/test_emails.py
+++ b/tests/test_emails.py
@@ -221,7 +221,7 @@ def test_send_hx2_access_group_discrepancy_notification():
         "Coldfront - HX2 Access Group Membership Discrepancy Detected"
     )
     assert message.body == expected_body.lstrip()
-    
+
 
 @pytest.mark.parametrize(
     "send_email, arguments",


### PR DESCRIPTION
# Description

This PR updates the allocation status change notification emails to include a high priority flag.

The `send_mail` is replaced with the `EmailMessage` from `django.core.mail` to include custom headers.

Fixes #333 

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [x] All tests pass (eg. `python -m pytest`)
- [x] The documentation builds and looks OK (eg. `python -m sphinx -b html docs docs/build`)
- [x] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
