### PR TITLE
Include ENV in RDF allocation lifecycle

### DIFF
--- a/imperial_coldfront_plugin/settings.py
+++ b/imperial_coldfront_plugin/settings.py
@@ -187,7 +187,7 @@ RDF_ALLOCATION_DELETION_NOTIFICATION_SCHEDULE = ENV.list(
 """Days after expiry to send deletion notifications."""
 
 
-def validate_rdf_allocation_lifecycle_settings():
+def validate_rdf_allocation_lifecycle_settings() -> None:
     """Validate the RDF allocation lifecycle settings are consistent.
 
     Raises:

--- a/imperial_coldfront_plugin/settings.py
+++ b/imperial_coldfront_plugin/settings.py
@@ -9,6 +9,7 @@ from string import ascii_lowercase, digits
 import django_stubs_ext
 import pint
 from coldfront.config.env import ENV
+from django.core.exceptions import ImproperlyConfigured
 
 from .acl import ACL, ACLEntry
 
@@ -184,6 +185,76 @@ RDF_ALLOCATION_DELETION_NOTIFICATION_SCHEDULE = ENV.list(
     "RDF_ALLOCATION_DELETION_NOTIFICATION_SCHEDULE", default=[-14]
 )
 """Days after expiry to send deletion notifications."""
+
+
+def validate_rdf_allocation_lifecycle_settings():
+    """Validate the RDF allocation lifecycle settings are consistent.
+
+    Raises:
+        ImproperlyConfigured: If the settings are inconsistent.
+    """
+    if not ENABLE_RDF_ALLOCATION_LIFECYCLE:
+        return
+
+    for val in RDF_ALLOCATION_EXPIRY_WARNING_SCHEDULE:
+        if val <= 1:
+            raise ImproperlyConfigured(
+                f"RDF_ALLOCATION_EXPIRY_WARNING_SCHEDULE contains a value {val}, "
+                "but it should contain only values >=1."
+            )
+
+    for val in RDF_ALLOCATION_REMOVAL_WARNING_SCHEDULE:
+        if val > 0:
+            raise ImproperlyConfigured(
+                f"RDF_ALLOCATION_REMOVAL_WARNING_SCHEDULE contains a value {val}, "
+                "but it should contain only values <=0."
+            )
+
+    for val in RDF_ALLOCATION_DELETION_WARNING_SCHEDULE:
+        if val > 0:
+            raise ImproperlyConfigured(
+                f"RDF_ALLOCATION_DELETION_WARNING_SCHEDULE contains a value {val}, "
+                "but it should contain only values <=0."
+            )
+
+    for val in RDF_ALLOCATION_DELETION_NOTIFICATION_SCHEDULE:
+        if val > 0:
+            raise ImproperlyConfigured(
+                f"RDF_ALLOCATION_DELETION_NOTIFICATION_SCHEDULE contains a value {val},"
+                "but it should contain only values <=0."
+            )
+
+    max_expiry_warning = max(RDF_ALLOCATION_EXPIRY_WARNING_SCHEDULE)
+    max_removal_warning = max(RDF_ALLOCATION_REMOVAL_WARNING_SCHEDULE)
+    max_deletion_warning = max(RDF_ALLOCATION_DELETION_WARNING_SCHEDULE)
+    max_deletion_notification = max(RDF_ALLOCATION_DELETION_NOTIFICATION_SCHEDULE)
+
+    if not (max_expiry_warning > max_removal_warning):
+        raise ImproperlyConfigured(
+            f"RDF_ALLOCATION_EXPIRY_WARNING_SCHEDULE must have a maximum value "
+            f"(current: {max_expiry_warning}) greater than the maximum value of "
+            f"RDF_ALLOCATION_REMOVAL_WARNING_SCHEDULE (current: {max_removal_warning})."
+        )
+
+    if not (max_removal_warning > max_deletion_warning):
+        raise ImproperlyConfigured(
+            f"RDF_ALLOCATION_REMOVAL_WARNING_SCHEDULE must have a maximum value "
+            f"(current: {max_removal_warning}) greater than the maximum value of "
+            f"RDF_ALLOCATION_DELETION_WARNING_SCHEDULE (current: "
+            f"{max_deletion_warning})."
+        )
+
+    if not (max_deletion_warning > max_deletion_notification):
+        raise ImproperlyConfigured(
+            f"RDF_ALLOCATION_DELETION_WARNING_SCHEDULE must have a maximum value "
+            f"(current: {max_deletion_warning}) greater than the maximum value of "
+            f"RDF_ALLOCATION_DELETION_NOTIFICATION_SCHEDULE (current: "
+            f"{max_deletion_notification})."
+        )
+
+
+validate_rdf_allocation_lifecycle_settings()
+
 
 # Mappings for faculty and department names and shortnames for development purposes.
 # These should be overridden in prod via prod_settings.py.

--- a/imperial_coldfront_plugin/settings.py
+++ b/imperial_coldfront_plugin/settings.py
@@ -9,9 +9,9 @@ from string import ascii_lowercase, digits
 import django_stubs_ext
 import pint
 from coldfront.config.env import ENV
-from django.core.exceptions import ImproperlyConfigured
 
 from .acl import ACL, ACLEntry
+from .settings_validation import validate_schedules
 
 django_stubs_ext.monkeypatch()
 
@@ -167,94 +167,32 @@ RDF_ALLOCATION_EXPIRY_UNLINK_DAYS = ENV.int(
 
 # RDF Allocation Expiry Notification Schedules
 RDF_ALLOCATION_EXPIRY_WARNING_SCHEDULE = ENV.list(
-    "RDF_ALLOCATION_EXPIRY_WARNING_SCHEDULE", default=[90, 60, 30, 7, 1]
+    "RDF_ALLOCATION_EXPIRY_WARNING_SCHEDULE", default=[90, 60, 30, 7, 1], cast=int
 )
 """Days before expiry to send expiry warning notifications."""
 
 RDF_ALLOCATION_REMOVAL_WARNING_SCHEDULE = ENV.list(
-    "RDF_ALLOCATION_REMOVAL_WARNING_SCHEDULE", default=[0, -3, -6]
+    "RDF_ALLOCATION_REMOVAL_WARNING_SCHEDULE", default=[0, -3, -6], cast=int
 )
 """Days relative to expiry to send removal warning notifications."""
 
 RDF_ALLOCATION_DELETION_WARNING_SCHEDULE = ENV.list(
-    "RDF_ALLOCATION_DELETION_WARNING_SCHEDULE", default=[-7, -10, -13]
+    "RDF_ALLOCATION_DELETION_WARNING_SCHEDULE", default=[-7, -10, -13], cast=int
 )
 """Days after expiry to send deletion warning notifications."""
 
 RDF_ALLOCATION_DELETION_NOTIFICATION_SCHEDULE = ENV.list(
-    "RDF_ALLOCATION_DELETION_NOTIFICATION_SCHEDULE", default=[-14]
+    "RDF_ALLOCATION_DELETION_NOTIFICATION_SCHEDULE", default=[-14], cast=int
 )
 """Days after expiry to send deletion notifications."""
 
-
-def validate_rdf_allocation_lifecycle_settings() -> None:
-    """Validate the RDF allocation lifecycle settings are consistent.
-
-    Raises:
-        ImproperlyConfigured: If the settings are inconsistent.
-    """
-    if not ENABLE_RDF_ALLOCATION_LIFECYCLE:
-        return
-
-    for val in RDF_ALLOCATION_EXPIRY_WARNING_SCHEDULE:
-        if val <= 1:
-            raise ImproperlyConfigured(
-                f"RDF_ALLOCATION_EXPIRY_WARNING_SCHEDULE contains a value {val}, "
-                "but it should contain only values >=1."
-            )
-
-    for val in RDF_ALLOCATION_REMOVAL_WARNING_SCHEDULE:
-        if val > 0:
-            raise ImproperlyConfigured(
-                f"RDF_ALLOCATION_REMOVAL_WARNING_SCHEDULE contains a value {val}, "
-                "but it should contain only values <=0."
-            )
-
-    for val in RDF_ALLOCATION_DELETION_WARNING_SCHEDULE:
-        if val > 0:
-            raise ImproperlyConfigured(
-                f"RDF_ALLOCATION_DELETION_WARNING_SCHEDULE contains a value {val}, "
-                "but it should contain only values <=0."
-            )
-
-    for val in RDF_ALLOCATION_DELETION_NOTIFICATION_SCHEDULE:
-        if val > 0:
-            raise ImproperlyConfigured(
-                f"RDF_ALLOCATION_DELETION_NOTIFICATION_SCHEDULE contains a value {val},"
-                "but it should contain only values <=0."
-            )
-
-    max_expiry_warning = max(RDF_ALLOCATION_EXPIRY_WARNING_SCHEDULE)
-    max_removal_warning = max(RDF_ALLOCATION_REMOVAL_WARNING_SCHEDULE)
-    max_deletion_warning = max(RDF_ALLOCATION_DELETION_WARNING_SCHEDULE)
-    max_deletion_notification = max(RDF_ALLOCATION_DELETION_NOTIFICATION_SCHEDULE)
-
-    if not (max_expiry_warning > max_removal_warning):
-        raise ImproperlyConfigured(
-            f"RDF_ALLOCATION_EXPIRY_WARNING_SCHEDULE must have a maximum value "
-            f"(current: {max_expiry_warning}) greater than the maximum value of "
-            f"RDF_ALLOCATION_REMOVAL_WARNING_SCHEDULE (current: {max_removal_warning})."
-        )
-
-    if not (max_removal_warning > max_deletion_warning):
-        raise ImproperlyConfigured(
-            f"RDF_ALLOCATION_REMOVAL_WARNING_SCHEDULE must have a maximum value "
-            f"(current: {max_removal_warning}) greater than the maximum value of "
-            f"RDF_ALLOCATION_DELETION_WARNING_SCHEDULE (current: "
-            f"{max_deletion_warning})."
-        )
-
-    if not (max_deletion_warning > max_deletion_notification):
-        raise ImproperlyConfigured(
-            f"RDF_ALLOCATION_DELETION_WARNING_SCHEDULE must have a maximum value "
-            f"(current: {max_deletion_warning}) greater than the maximum value of "
-            f"RDF_ALLOCATION_DELETION_NOTIFICATION_SCHEDULE (current: "
-            f"{max_deletion_notification})."
-        )
-
-
-validate_rdf_allocation_lifecycle_settings()
-
+if ENABLE_RDF_ALLOCATION_LIFECYCLE:
+    validate_schedules(
+        RDF_ALLOCATION_EXPIRY_WARNING_SCHEDULE,
+        RDF_ALLOCATION_REMOVAL_WARNING_SCHEDULE,
+        RDF_ALLOCATION_DELETION_WARNING_SCHEDULE,
+        RDF_ALLOCATION_DELETION_NOTIFICATION_SCHEDULE,
+    )
 
 # Mappings for faculty and department names and shortnames for development purposes.
 # These should be overridden in prod via prod_settings.py.

--- a/imperial_coldfront_plugin/settings.py
+++ b/imperial_coldfront_plugin/settings.py
@@ -141,32 +141,49 @@ ALLOCATION_SHORTNAME_MAX_LENGTH = 12
 ALLOCATION_DEFAULT_PERIOD_DAYS = 365
 """Days from current date for the initial form default end date for an allocation."""
 
-# RDF Allocation Expiry Notification Schedules
-RDF_ALLOCATION_EXPIRY_WARNING_SCHEDULE = [90, 60, 30, 7, 1]
-"""Days before expiry to send expiry warning notifications."""
-
-RDF_ALLOCATION_REMOVAL_WARNING_SCHEDULE = [0, -3, -6]
-"""Days relative to expiry to send removal warning notifications."""
-
-RDF_ALLOCATION_DELETION_WARNING_SCHEDULE = [-7, -10, -13]
-"""Days after expiry to send deletion warning notifications."""
-
-RDF_ALLOCATION_DELETION_NOTIFICATION_SCHEDULE = [-14]
-"""Days after expiry to send deletion notifications."""
-
 SHOW_CREDIT_BALANCE = ENV.bool("SHOW_CREDIT_BALANCE", default=False)
 """Whether to display the credit balance section on project detail pages."""
-
-RDF_ALLOCATION_EXPIRY_REMOVAL_DAYS = 7
-"""Number of days after allocation expires to mark as removed."""
-
-RDF_ALLOCATION_EXPIRY_DELETION_DAYS = 14
-"""Number of days after an allocation expiry to mark as deleted."""
 
 ENABLE_RDF_ALLOCATION_LIFECYCLE = ENV.bool(
     "ENABLE_RDF_ALLOCATION_LIFECYCLE", default=False
 )
 """Feature flag to enable or disable the allocation lifecycle management."""
+
+RDF_ALLOCATION_EXPIRY_REMOVAL_DAYS = ENV.int(
+    "RDF_ALLOCATION_EXPIRY_REMOVAL_DAYS", default=7
+)
+"""Number of days after allocation expires to mark as removed."""
+
+RDF_ALLOCATION_EXPIRY_DELETION_DAYS = ENV.int(
+    "RDF_ALLOCATION_EXPIRY_DELETION_DAYS", default=14
+)
+"""Number of days after an allocation expiry to mark as deleted."""
+
+RDF_ALLOCATION_EXPIRY_UNLINK_DAYS = ENV.int(
+    "RDF_ALLOCATION_EXPIRY_UNLINK_DAYS", default=7
+)
+"""Number of days after an allocation expires to unlink from project."""
+
+# RDF Allocation Expiry Notification Schedules
+RDF_ALLOCATION_EXPIRY_WARNING_SCHEDULE = ENV.list(
+    "RDF_ALLOCATION_EXPIRY_WARNING_SCHEDULE", default=[90, 60, 30, 7, 1]
+)
+"""Days before expiry to send expiry warning notifications."""
+
+RDF_ALLOCATION_REMOVAL_WARNING_SCHEDULE = ENV.list(
+    "RDF_ALLOCATION_REMOVAL_WARNING_SCHEDULE", default=[0, -3, -6]
+)
+"""Days relative to expiry to send removal warning notifications."""
+
+RDF_ALLOCATION_DELETION_WARNING_SCHEDULE = ENV.list(
+    "RDF_ALLOCATION_DELETION_WARNING_SCHEDULE", default=[-7, -10, -13]
+)
+"""Days after expiry to send deletion warning notifications."""
+
+RDF_ALLOCATION_DELETION_NOTIFICATION_SCHEDULE = ENV.list(
+    "RDF_ALLOCATION_DELETION_NOTIFICATION_SCHEDULE", default=[-14]
+)
+"""Days after expiry to send deletion notifications."""
 
 # Mappings for faculty and department names and shortnames for development purposes.
 # These should be overridden in prod via prod_settings.py.
@@ -191,9 +208,6 @@ DEPARTMENTS_IN_FACULTY = {
 
 GPFS_AD_SYNC_TIMEOUT_SECONDS = ENV.int("GPFS_AD_SYNC_TIMEOUT_SECONDS", default=600)
 """Maximum wait time configured for exponential backoff retries for fileset creation."""
-
-RDF_ALLOCATION_EXPIRY_UNLINK_DAYS = 7
-"""Number of days after an allocation expires to unlink from project."""
 
 ENABLE_USER_GROUP_CREATION = ENV.bool("ENABLE_USER_GROUP_CREATION", default=False)
 """Feature flag to enable or disable creation of user groups for allocations."""

--- a/imperial_coldfront_plugin/settings_validation.py
+++ b/imperial_coldfront_plugin/settings_validation.py
@@ -1,0 +1,48 @@
+"""Helpers for validating settings in the Imperial Coldfront plugin."""
+
+from itertools import pairwise
+
+from django.core.exceptions import ImproperlyConfigured
+
+
+def validate_schedules(
+    expiry_warning_schedule: list[int],
+    removal_warning_schedule: list[int],
+    deletion_warning_schedule: list[int],
+    deletion_notification_schedule: list[int],
+) -> None:
+    """Validate the notification schedules for RDF allocations.
+
+    Args:
+        expiry_warning_schedule: days before expiry to send expiry warnings.
+        removal_warning_schedule: days after to expiry to send removal warnings.
+        deletion_warning_schedule: days after expiry to send deletion warnings.
+        deletion_notification_schedule: days after expiry to send notifications.
+
+    Raises:
+        ImproperlyConfigured: If any of the schedules are misconfigured.
+    """
+    if any(val < 1 for val in expiry_warning_schedule):
+        raise ImproperlyConfigured(
+            "RDF_ALLOCATION_EXPIRY_WARNING_SCHEDULE must contain only positive integers"
+        )
+
+    if any(val > 0 for val in removal_warning_schedule):
+        raise ImproperlyConfigured(
+            "RDF_ALLOCATION_REMOVAL_WARNING_SCHEDULE must contain only non-positive "
+            "integers"
+        )
+
+    for schedule1, schedule2 in pairwise(
+        (
+            expiry_warning_schedule,
+            removal_warning_schedule,
+            deletion_warning_schedule,
+            deletion_notification_schedule,
+        )
+    ):
+        if max(schedule2) >= min(schedule1):
+            raise ImproperlyConfigured(
+                "Misconfiguration detected in RDF allocation notification schedule. "
+                "Schedules must be correctly sequenced and non-overlapping."
+            )

--- a/tests/test_settings_validation.py
+++ b/tests/test_settings_validation.py
@@ -1,0 +1,51 @@
+import pytest
+from django.core.exceptions import ImproperlyConfigured
+
+from imperial_coldfront_plugin.settings_validation import validate_schedules
+
+
+def test_validate_schedules_valid():
+    """Test validate_schedules with valid schedules."""
+    validate_schedules([5, 3, 1], [0, -1, -2], [-3, -4, -5], [-6, -7, -8])
+
+
+@pytest.mark.parametrize("value", (0, -1))
+def test_validate_schedules_positive_integers(value):
+    """Test validate_schedules with invalid schedules."""
+    with pytest.raises(
+        ImproperlyConfigured,
+        match=(
+            "RDF_ALLOCATION_EXPIRY_WARNING_SCHEDULE must contain only positive integers"
+        ),
+    ):
+        validate_schedules([value, -2, -3], [-4, -5, -6], [-7, -8, -9], [-10, -11, -12])
+
+
+def test_validate_schedule_non_positive_integers():
+    """Test validate_schedules with invalid schedules."""
+    with pytest.raises(
+        ImproperlyConfigured,
+        match=(
+            "RDF_ALLOCATION_REMOVAL_WARNING_SCHEDULE must contain only non-positive "
+            "integers"
+        ),
+    ):
+        validate_schedules([5, 4, 3], [1, 0, -2], [-3, -4, -5], [-6, -7, -8])
+
+
+def test_validate_schedule_overlap():
+    """Test validate_schedules with overlapping schedules."""
+    with pytest.raises(
+        ImproperlyConfigured,
+        match="Misconfiguration detected in RDF allocation notification schedule",
+    ):
+        validate_schedules([5, 4, 3], [0, -1, -3], [-2, -4, -5], [-6, -7, -8])
+
+
+def test_validate_schedule_out_of_sequence():
+    """Test validate_schedules with mis-ordered schedules."""
+    with pytest.raises(
+        ImproperlyConfigured,
+        match="Misconfiguration detected in RDF allocation notification schedule",
+    ):
+        validate_schedules([5, 4, 3], [-3, -4, -5], [0, -1, -2], [-6, -7, -8])


### PR DESCRIPTION
# Description

This PR updates the RDF allocation lifecycle and notification settings in `settings.py`. The hardcoded configuration values are changed to environment variables using `ENV`.

Fixes #343 

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [ ] All tests pass (eg. `python -m pytest`)
- [ ] The documentation builds and looks OK (eg. `python -m sphinx -b html docs docs/build`)
- [ ] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
