### PR TITLE
Improve consistency checks to be used as standalone

### DIFF
--- a/imperial_coldfront_plugin/emails.py
+++ b/imperial_coldfront_plugin/emails.py
@@ -37,6 +37,19 @@ class DiscrepancyCheckResult:
         return bool(self.membership_discrepancies or self.missing_ldap_groups)
 
 
+@dataclass
+class QuotaConsistencyCheckResult:
+    """Result of a quota consistency check."""
+
+    discrepancies: list["QuotaDiscrepancy"]
+    missing_filesets: list[str]
+
+    @property
+    def discrepancies_found(self) -> bool:
+        """Whether any discrepancies were found."""
+        return bool(self.discrepancies or self.missing_filesets)
+
+
 def send_discrepancy_notification(
     check_result: DiscrepancyCheckResult, source: str
 ) -> None:

--- a/imperial_coldfront_plugin/emails.py
+++ b/imperial_coldfront_plugin/emails.py
@@ -2,7 +2,7 @@
 
 import textwrap
 from dataclasses import dataclass
-from typing import TypedDict
+from typing import Literal
 
 from django.conf import settings
 from django.core.mail import EmailMessage, mail_admins, send_mail
@@ -38,10 +38,20 @@ class DiscrepancyCheckResult:
 
 
 @dataclass
+class QuotaDiscrepancy:
+    """Structure for holding discrepancies found during quota consistency check."""
+
+    fileset: str
+    type: Literal["storage", "files"]
+    attribute_value: int
+    fileset_value: int
+
+
+@dataclass
 class QuotaConsistencyCheckResult:
     """Result of a quota consistency check."""
 
-    discrepancies: list["QuotaDiscrepancy"]
+    discrepancies: list[QuotaDiscrepancy]
     missing_filesets: list[str]
 
     @property
@@ -241,16 +251,6 @@ def notify_platforms_to_manually_delete_allocation(
     )
 
 
-class QuotaDiscrepancy(TypedDict):
-    """Structure for holding discrepancies found during quota consistency check."""
-
-    shortname: str
-    attribute_storage_quota: int | None
-    fileset_storage_quota: float | None
-    attribute_files_quota: int | None
-    fileset_files_quota: float | None
-
-
 def send_quota_discrepancy_notification(discrepancies: list[QuotaDiscrepancy]) -> None:
     """Send quota discrepancy notification to project owner.
 
@@ -269,24 +269,14 @@ def send_quota_discrepancy_notification(discrepancies: list[QuotaDiscrepancy]) -
     )
 
     for discrepancy in discrepancies:
-        shortname = discrepancy["shortname"]
+        shortname = discrepancy.fileset
         message += f"\t- Allocation shortname: {shortname}\n"
 
-        if discrepancy["attribute_storage_quota"]:
-            attribute_storage_quota = discrepancy["attribute_storage_quota"]
-            fileset_storage_quota = discrepancy["fileset_storage_quota"]
-            message += (
-                f"\t\tAllocation storage quota of {attribute_storage_quota}, "
-                f"GPFS storage quota of {fileset_storage_quota}.\n"
-            )
-
-        if discrepancy["attribute_files_quota"]:
-            attribute_files_quota = discrepancy["attribute_files_quota"]
-            fileset_files_quota = discrepancy["fileset_files_quota"]
-            message += (
-                f"\t\tAllocation files quota of {attribute_files_quota}, "
-                f"GPFS files quota of {fileset_files_quota}.\n"
-            )
+        message += (
+            f"\t\tAllocation {discrepancy.type} quota of "
+            f"{discrepancy.attribute_value}, GPFS {discrepancy.type} quota of "
+            f"{discrepancy.fileset_value}.\n"
+        )
 
     mail_admins(
         subject="Coldfront Quota Consistency Check - Discrepancies Found",

--- a/imperial_coldfront_plugin/tasks.py
+++ b/imperial_coldfront_plugin/tasks.py
@@ -27,6 +27,7 @@ from imperial_coldfront_plugin.models import (
 from .emails import (
     Discrepancy,
     DiscrepancyCheckResult,
+    QuotaConsistencyCheckResult,
     QuotaDiscrepancy,
     notify_platforms_to_manually_delete_allocation,
     send_allocation_deletion_notification,
@@ -552,16 +553,22 @@ def zero_allocation_gpfs_quota(allocation_id: int) -> None:
     )
 
 
-def check_quota_consistency(send_email: bool = True) -> None:
+def check_quota_consistency(
+    send_email: bool = True,
+) -> QuotaConsistencyCheckResult | None:
     """Check consistency of file and storage quotas between allocations and filesets.
 
     Compares the active allocations to ensure the matching filesets have the same
     storage and file quotas. If discrepancies are found, a notification email is sent
     to admins. Also sends a notification if any allocations are found that do not have a
     matching fileset in GPFS.
+
+    Returns:
+        A QuotaConsistencyCheckResult object containing the discrepancies and missing
+        filesets, or None if GPFS is not enabled.
     """
     if not settings.GPFS_ENABLED:
-        return
+        return None
 
     allocations = RDFAllocation.objects.filter(
         resources__name="RDF Active",
@@ -623,6 +630,10 @@ def check_quota_consistency(send_email: bool = True) -> None:
 
     if missing_filesets and send_email:
         send_fileset_not_found_notification(missing_filesets)
+
+    return QuotaConsistencyCheckResult(
+        discrepancies=discrepancies, missing_filesets=missing_filesets
+    )
 
 
 def unlink_expired_allocation_filesets() -> None:

--- a/imperial_coldfront_plugin/tasks.py
+++ b/imperial_coldfront_plugin/tasks.py
@@ -269,7 +269,9 @@ def find_discrepancies_helper(
     )
 
 
-def check_rdf_ldap_consistency() -> DiscrepancyCheckResult | None:
+def check_rdf_ldap_consistency(
+    send_email: bool = True,
+) -> DiscrepancyCheckResult | None:
     """Check the consistency of LDAP groups with the RDF Active allocations."""
     if not settings.LDAP_ENABLED:
         return None
@@ -282,13 +284,15 @@ def check_rdf_ldap_consistency() -> DiscrepancyCheckResult | None:
 
     check_result = find_discrepancies_helper(allocations, ldap_groups)
 
-    if check_result.discrepancies_found:
+    if check_result.discrepancies_found and send_email:
         send_discrepancy_notification(check_result, source="RDF")
 
     return check_result
 
 
-def check_hx2_ldap_consistency() -> DiscrepancyCheckResult | None:
+def check_hx2_ldap_consistency(
+    send_email: bool = True,
+) -> DiscrepancyCheckResult | None:
     """Check the consistency of LDAP groups with the HX2 allocations in the database."""
     if not settings.LDAP_ENABLED:
         return None
@@ -301,7 +305,7 @@ def check_hx2_ldap_consistency() -> DiscrepancyCheckResult | None:
 
     check_result = find_discrepancies_helper(allocations, ldap_groups)
 
-    if check_result.discrepancies_found:
+    if check_result.discrepancies_found and send_email:
         send_discrepancy_notification(check_result, source="HX2")
 
     return check_result
@@ -385,7 +389,7 @@ def update_allocation_status() -> None:
         )
 
 
-def check_rdf_allocation_expiry_notifications() -> None:
+def check_rdf_allocation_expiry_notifications(send_email: bool = True) -> None:
     """Check RDF allocations and send appropriate expiry notifications."""
     if not settings.ENABLE_RDF_ALLOCATION_LIFECYCLE:
         return
@@ -424,9 +428,10 @@ def check_rdf_allocation_expiry_notifications() -> None:
         logger.info(
             f"Sending expiry warning for allocation {allocation.pk} ({days_until_expiry} days)"  # noqa:E501
         )
-        send_allocation_expiry_warning(
-            allocation.pk, project_owner.email, days_until_expiry
-        )
+        if send_email:
+            send_allocation_expiry_warning(
+                allocation.pk, project_owner.email, days_until_expiry
+            )
 
     # Query for removal warnings
     removal_allocations = RDFAllocation.objects.filter(
@@ -440,9 +445,10 @@ def check_rdf_allocation_expiry_notifications() -> None:
         logger.info(
             f"Sending removal warning for allocation {allocation.pk} ({days_until_expiry} days)"  # noqa:E501
         )
-        send_allocation_removal_warning(
-            allocation.pk, project_owner.email, days_until_expiry
-        )
+        if send_email:
+            send_allocation_removal_warning(
+                allocation.pk, project_owner.email, days_until_expiry
+            )
 
     # Query for deletion warnings
     deletion_warning_allocations = RDFAllocation.objects.filter(
@@ -456,9 +462,10 @@ def check_rdf_allocation_expiry_notifications() -> None:
         logger.info(
             f"Sending deletion warning for allocation {allocation.pk} ({days_until_expiry} days)"  # noqa:E501
         )
-        send_allocation_deletion_warning(
-            allocation.pk, project_owner.email, days_until_expiry
-        )
+        if send_email:
+            send_allocation_deletion_warning(
+                allocation.pk, project_owner.email, days_until_expiry
+            )
 
     # Query for deletion notifications
     deletion_notification_allocations = RDFAllocation.objects.filter(
@@ -469,7 +476,8 @@ def check_rdf_allocation_expiry_notifications() -> None:
         project_owner = allocation.project.pi
 
         logger.info(f"Sending deletion notification for allocation {allocation.pk}")
-        send_allocation_deletion_notification(allocation.pk, project_owner.email)
+        if send_email:
+            send_allocation_deletion_notification(allocation.pk, project_owner.email)
 
     logger.info(
         f"Sent {expiry_allocations.count()} expiry warnings, "
@@ -538,7 +546,7 @@ def zero_allocation_gpfs_quota(allocation_id: int) -> None:
     )
 
 
-def check_quota_consistency() -> None:
+def check_quota_consistency(send_email: bool = True) -> None:
     """Check consistency of file and storage quotas between allocations and filesets.
 
     Compares the active allocations to ensure the matching filesets have the same
@@ -604,10 +612,10 @@ def check_quota_consistency() -> None:
             # The allocation was not found in GPFS - notify admins
             missing_filesets.append(shortname)
 
-    if discrepancies:
+    if discrepancies and send_email:
         send_quota_discrepancy_notification(discrepancies)
 
-    if missing_filesets:
+    if missing_filesets and send_email:
         send_fileset_not_found_notification(missing_filesets)
 
 
@@ -651,7 +659,7 @@ def unlink_expired_allocation_filesets() -> None:
             logger.exception(f"Error unlinking fileset for allocation {shortname}")
 
 
-def check_hx2_user_group_consistency() -> Discrepancy | None:
+def check_hx2_user_group_consistency(send_email: bool = True) -> Discrepancy | None:
     """Check consistency of user group memberships for HX2 allocations."""
     if not settings.LDAP_ENABLED:
         return None
@@ -684,6 +692,7 @@ def check_hx2_user_group_consistency() -> Discrepancy | None:
         extra_members=extra_members,
     )
 
-    send_hx2_access_group_discrepancy_notification(check_result)
+    if send_email:
+        send_hx2_access_group_discrepancy_notification(check_result)
 
     return check_result

--- a/imperial_coldfront_plugin/tasks.py
+++ b/imperial_coldfront_plugin/tasks.py
@@ -426,11 +426,11 @@ def check_rdf_allocation_expiry_notifications(send_email: bool = True) -> None:
         days_until_expiry = (allocation.end_date - today).days
         project_owner = allocation.project.pi
 
-        logger.info(
-            f"{'Sending' if send_email else 'Dry run: would send'} expiry "
-            f"warning for allocation {allocation.pk} ({days_until_expiry} days)"
-        )
         if send_email:
+            logger.info(
+                "Sending expiry warning for allocation "
+                f"{allocation.pk} ({days_until_expiry} days)"
+            )
             send_allocation_expiry_warning(
                 allocation.pk, project_owner.email, days_until_expiry
             )
@@ -444,11 +444,11 @@ def check_rdf_allocation_expiry_notifications(send_email: bool = True) -> None:
         days_until_expiry = (allocation.end_date - today).days
         project_owner = allocation.project.pi
 
-        logger.info(
-            f"{'Sending' if send_email else 'Dry run: would send'} removal "
-            f"warning for allocation {allocation.pk} ({days_until_expiry} days)"
-        )
         if send_email:
+            logger.info(
+                "Sending removal warning for allocation "
+                f"{allocation.pk} ({days_until_expiry} days)"
+            )
             send_allocation_removal_warning(
                 allocation.pk, project_owner.email, days_until_expiry
             )
@@ -462,11 +462,11 @@ def check_rdf_allocation_expiry_notifications(send_email: bool = True) -> None:
         days_until_expiry = (allocation.end_date - today).days
         project_owner = allocation.project.pi
 
-        logger.info(
-            f"{'Sending' if send_email else 'Dry run: would send'} deletion "
-            f"warning for allocation {allocation.pk} ({days_until_expiry} days)"
-        )
         if send_email:
+            logger.info(
+                "Sending deletion warning for allocation "
+                f"{allocation.pk} ({days_until_expiry} days)"
+            )
             send_allocation_deletion_warning(
                 allocation.pk, project_owner.email, days_until_expiry
             )
@@ -479,15 +479,12 @@ def check_rdf_allocation_expiry_notifications(send_email: bool = True) -> None:
     for allocation in deletion_notification_allocations:
         project_owner = allocation.project.pi
 
-        logger.info(
-            f"{'Sending' if send_email else 'Dry run: would send'} deletion "
-            f"notification for allocation {allocation.pk}"
-        )
         if send_email:
+            logger.info(f"Sending deletion notification for allocation {allocation.pk}")
             send_allocation_deletion_notification(allocation.pk, project_owner.email)
 
     logger.info(
-        f"Sent {expiry_allocations.count()} expiry warnings, "
+        f"Identified {expiry_allocations.count()} expiry warnings, "
         f"{removal_allocations.count()} removal warnings, "
         f"{deletion_warning_allocations.count()} deletion warnings, "
         f"{deletion_notification_allocations.count()} deletion notifications"
@@ -584,42 +581,32 @@ def check_quota_consistency(
 
     for allocation in allocations:
         shortname = allocation.shortname
-        storage_attribute_quota: int = allocation.storage_quota_tb
-        files_attribute_quota: int = allocation.files_quota
+        storage_attribute_quota = allocation.storage_quota_tb
+        files_attribute_quota = allocation.files_quota
 
         if shortname in usages:
             # Check for discrepancies between the allocation and fileset for both
             # storage and file quotas.
-            storage_quota_discrepancy = (
-                storage_attribute_quota != usages[shortname]["block_limit_tb"]
-            )
-            file_quota_discrepancy = (
-                files_attribute_quota != usages[shortname]["files_limit"]
-            )
-            if storage_quota_discrepancy or file_quota_discrepancy:
-                # If either are not consistent, create a discrepancy record.
+            storage_fileset_quota = int(usages[shortname]["block_limit_tb"])
+            if storage_attribute_quota != storage_fileset_quota:
                 discrepancies.append(
-                    {
-                        "shortname": shortname,
-                        "attribute_storage_quota": (
-                            storage_attribute_quota
-                            if storage_quota_discrepancy
-                            else None
-                        ),
-                        "fileset_storage_quota": (
-                            usages[shortname]["block_limit_tb"]
-                            if storage_quota_discrepancy
-                            else None
-                        ),
-                        "attribute_files_quota": (
-                            files_attribute_quota if file_quota_discrepancy else None
-                        ),
-                        "fileset_files_quota": (
-                            usages[shortname]["files_limit"]
-                            if file_quota_discrepancy
-                            else None
-                        ),
-                    }
+                    QuotaDiscrepancy(
+                        type="storage",
+                        fileset=shortname,
+                        attribute_value=storage_attribute_quota,
+                        fileset_value=storage_fileset_quota,
+                    )
+                )
+
+            files_fileset_quota = int(usages[shortname]["files_limit"])
+            if files_attribute_quota != files_fileset_quota:
+                discrepancies.append(
+                    QuotaDiscrepancy(
+                        type="files",
+                        fileset=shortname,
+                        attribute_value=files_attribute_quota,
+                        fileset_value=files_fileset_quota,
+                    )
                 )
         else:
             # The allocation was not found in GPFS - notify admins

--- a/imperial_coldfront_plugin/tasks.py
+++ b/imperial_coldfront_plugin/tasks.py
@@ -426,7 +426,8 @@ def check_rdf_allocation_expiry_notifications(send_email: bool = True) -> None:
         project_owner = allocation.project.pi
 
         logger.info(
-            f"Sending expiry warning for allocation {allocation.pk} ({days_until_expiry} days)"  # noqa:E501
+            f"{'Sending' if send_email else 'Dry run: would send'} expiry "
+            f"warning for allocation {allocation.pk} ({days_until_expiry} days)"
         )
         if send_email:
             send_allocation_expiry_warning(
@@ -443,7 +444,8 @@ def check_rdf_allocation_expiry_notifications(send_email: bool = True) -> None:
         project_owner = allocation.project.pi
 
         logger.info(
-            f"Sending removal warning for allocation {allocation.pk} ({days_until_expiry} days)"  # noqa:E501
+            f"{'Sending' if send_email else 'Dry run: would send'} removal "
+            f"warning for allocation {allocation.pk} ({days_until_expiry} days)"
         )
         if send_email:
             send_allocation_removal_warning(
@@ -460,7 +462,8 @@ def check_rdf_allocation_expiry_notifications(send_email: bool = True) -> None:
         project_owner = allocation.project.pi
 
         logger.info(
-            f"Sending deletion warning for allocation {allocation.pk} ({days_until_expiry} days)"  # noqa:E501
+            f"{'Sending' if send_email else 'Dry run: would send'} deletion "
+            f"warning for allocation {allocation.pk} ({days_until_expiry} days)"
         )
         if send_email:
             send_allocation_deletion_warning(
@@ -475,7 +478,10 @@ def check_rdf_allocation_expiry_notifications(send_email: bool = True) -> None:
     for allocation in deletion_notification_allocations:
         project_owner = allocation.project.pi
 
-        logger.info(f"Sending deletion notification for allocation {allocation.pk}")
+        logger.info(
+            f"{'Sending' if send_email else 'Dry run: would send'} deletion "
+            f"notification for allocation {allocation.pk}"
+        )
         if send_email:
             send_allocation_deletion_notification(allocation.pk, project_owner.email)
 

--- a/tests/test_emails.py
+++ b/tests/test_emails.py
@@ -10,6 +10,7 @@ from django.test import override_settings
 from imperial_coldfront_plugin.emails import (
     Discrepancy,
     DiscrepancyCheckResult,
+    QuotaDiscrepancy,
     notify_platforms_to_manually_delete_allocation,
     send_allocation_deletion_notification,
     send_allocation_deletion_warning,
@@ -31,27 +32,30 @@ def admin_email(settings):
 def test_send_quota_discrepancy_notification():
     """Test the quota discrepancy email."""
     discrepancies = [
-        {
-            "shortname": "bio-research-01",
-            "attribute_storage_quota": 500,
-            "fileset_storage_quota": 550,
-            "attribute_files_quota": 1000000,
-            "fileset_files_quota": 1200000,
-        },
-        {
-            "shortname": "physics-dept-lab",
-            "attribute_storage_quota": 2,
-            "fileset_storage_quota": 2.5,
-            "attribute_files_quota": None,
-            "fileset_files_quota": None,
-        },
-        {
-            "shortname": "chem-analysis",
-            "attribute_storage_quota": None,
-            "fileset_storage_quota": None,
-            "attribute_files_quota": 500000,
-            "fileset_files_quota": 600000,
-        },
+        QuotaDiscrepancy(
+            fileset="bio-research-01",
+            type="storage",
+            attribute_value=500,
+            fileset_value=550,
+        ),
+        QuotaDiscrepancy(
+            fileset="bio-research-01",
+            type="files",
+            attribute_value=1000000,
+            fileset_value=1200000,
+        ),
+        QuotaDiscrepancy(
+            fileset="physics-dept-lab",
+            type="storage",
+            attribute_value=2,
+            fileset_value=3,
+        ),
+        QuotaDiscrepancy(
+            fileset="chem-analysis",
+            type="files",
+            attribute_value=500000,
+            fileset_value=600000,
+        ),
     ]
 
     expected_message = """\
@@ -64,9 +68,10 @@ The following discrepancies were detected between Coldfront and GPFS:
 
 \t- Allocation shortname: bio-research-01
 \t\tAllocation storage quota of 500, GPFS storage quota of 550.
+\t- Allocation shortname: bio-research-01
 \t\tAllocation files quota of 1000000, GPFS files quota of 1200000.
 \t- Allocation shortname: physics-dept-lab
-\t\tAllocation storage quota of 2, GPFS storage quota of 2.5.
+\t\tAllocation storage quota of 2, GPFS storage quota of 3.
 \t- Allocation shortname: chem-analysis
 \t\tAllocation files quota of 500000, GPFS files quota of 600000.
 """

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -556,6 +556,30 @@ class TestCheckRDFLdapConsistency:
         assert result == DiscrepancyCheckResult([], [rdf_allocation_ldap_name])
         notify_mock.assert_called_once_with(result, source="RDF")
 
+    def test_no_email_when_send_email_false(
+        self,
+        rdf_allocation,
+        rdf_allocation_user,
+        ldap_group_search_mock,
+        notify_mock,
+        rdf_allocation_ldap_name,
+    ):
+        """Test that no email is sent when send_email is False."""
+        username = rdf_allocation_user.user.username
+        ldap_group_search_mock.return_value = {rdf_allocation_ldap_name: []}
+
+        result = check_rdf_ldap_consistency(send_email=False)
+        membership_discrepancies = result.membership_discrepancies
+
+        assert len(membership_discrepancies) == 1
+        discrepancy = membership_discrepancies[0]
+        assert discrepancy.group_name == rdf_allocation_ldap_name
+        assert discrepancy.project_name == rdf_allocation.project.title
+        assert discrepancy.missing_members == [username]
+        assert not discrepancy.extra_members
+
+        notify_mock.assert_not_called()
+
 
 class TestCheckHX2LdapConsistency:
     """Tests for check_hx2_ldap_consistency task."""
@@ -639,6 +663,30 @@ class TestCheckHX2LdapConsistency:
 
         assert result == DiscrepancyCheckResult([], [hx2_allocation.ldap_shortname])
         notify_mock.assert_called_once_with(result, source="HX2")
+
+    def test_no_email_when_send_email_false(
+        self,
+        hx2_allocation,
+        hx2_allocation_user,
+        ldap_group_search_mock,
+        notify_mock,
+    ):
+        """Test that no email is sent when send_email is False."""
+        username = hx2_allocation_user.user.username
+        ldap_name = hx2_allocation.ldap_shortname
+        ldap_group_search_mock.return_value = {ldap_name: []}
+
+        result = check_hx2_ldap_consistency(send_email=False)
+        membership_discrepancies = result.membership_discrepancies
+
+        assert len(membership_discrepancies) == 1
+        discrepancy = membership_discrepancies[0]
+        assert discrepancy.group_name == ldap_name
+        assert discrepancy.project_name == hx2_allocation.project.title
+        assert discrepancy.missing_members == [username]
+        assert not discrepancy.extra_members
+
+        notify_mock.assert_not_called()
 
 
 class TestRemoveLDAPGroupMembers:
@@ -1164,6 +1212,62 @@ class TestCheckQuotaConsistency:
         else:
             send_fileset_not_found_notification_mock.assert_called_once_with(["shorty"])
 
+    def test_no_email_when_send_email_false(
+        self,
+        project,
+        rdf_allocation,
+        rdf_allocation_factory,
+        send_quota_discrepancy_notification_mock,
+        send_fileset_not_found_notification_mock,
+        retrieve_all_fileset_quotas_mock,
+        allocation_attribute_factory,
+    ):
+        """Test that no email is sent when send_email is False."""
+        from imperial_coldfront_plugin.tasks import check_quota_consistency
+
+        discrepancy_allocation = rdf_allocation
+        missing_fileset_allocation = rdf_allocation_factory(
+            project=project,
+            shortname="missing_shortname",
+            gid=12345,
+        )
+
+        allocation_attribute_factory(
+            allocation=discrepancy_allocation,
+            name="Storage Quota (TB)",
+            value=1,
+        )
+
+        allocation_attribute_factory(
+            allocation=discrepancy_allocation,
+            name="Files Quota",
+            value=500,
+        )
+
+        allocation_attribute_factory(
+            allocation=missing_fileset_allocation,
+            name="Storage Quota (TB)",
+            value=2,
+        )
+
+        allocation_attribute_factory(
+            allocation=missing_fileset_allocation,
+            name="Files Quota",
+            value=1000,
+        )
+
+        retrieve_all_fileset_quotas_mock.return_value = {
+            "shorty": {
+                "files_limit": 700.0,
+                "block_limit_tb": 3.0,
+            }
+        }
+
+        check_quota_consistency(send_email=False)
+
+        send_quota_discrepancy_notification_mock.assert_not_called()
+        send_fileset_not_found_notification_mock.assert_not_called()
+
 
 class TestUnlinkExpiredAllocationFilesets:
     """Tests for unlink_expired_allocation_filesets task."""
@@ -1412,3 +1516,26 @@ class TestCheckHX2UserGroupConsistency:
             match=r"Unable to find HX2 access group in AD during consistency check.",
         ):
             check_hx2_user_group_consistency()
+
+    def test_no_email_when_send_email_false(
+        self,
+        hx2_allocation,
+        hx2_allocation_user,
+        ldap_group_search_mock,
+        notify_mock,
+        settings,
+    ):
+        """Test that no email is sent when send_email is False."""
+        username = hx2_allocation_user.user.username
+        ldap_name = settings.LDAP_HX2_ACCESS_GROUP_NAME
+        ldap_group_search_mock.return_value = {ldap_name: []}
+
+        discrepancy = check_hx2_user_group_consistency(send_email=False)
+        assert discrepancy == Discrepancy(
+            group_name=ldap_name,
+            project_name="",
+            missing_members=[username],
+            extra_members=[],
+        )
+
+        notify_mock.assert_not_called()

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -14,7 +14,11 @@ from coldfront.core.resource.models import Resource
 from django.conf import settings
 from django.utils import timezone
 
-from imperial_coldfront_plugin.emails import Discrepancy, DiscrepancyCheckResult
+from imperial_coldfront_plugin.emails import (
+    Discrepancy,
+    DiscrepancyCheckResult,
+    QuotaDiscrepancy,
+)
 from imperial_coldfront_plugin.forms import RDFAllocationForm
 from imperial_coldfront_plugin.gid import get_new_gid
 from imperial_coldfront_plugin.gpfs_client import FilesetPathInfo
@@ -1105,13 +1109,12 @@ class TestCheckQuotaConsistency:
                 500.0,
                 "shorty",
                 [
-                    {
-                        "shortname": "shorty",
-                        "attribute_storage_quota": 1,
-                        "fileset_storage_quota": 2.0,
-                        "attribute_files_quota": None,
-                        "fileset_files_quota": None,
-                    }
+                    QuotaDiscrepancy(
+                        fileset="shorty",
+                        type="storage",
+                        attribute_value=1,
+                        fileset_value=2,
+                    )
                 ],
             ),
             # Case 3: Files quota discrepancy only
@@ -1122,13 +1125,12 @@ class TestCheckQuotaConsistency:
                 600.0,
                 "shorty",
                 [
-                    {
-                        "shortname": "shorty",
-                        "attribute_storage_quota": None,
-                        "fileset_storage_quota": None,
-                        "attribute_files_quota": 500,
-                        "fileset_files_quota": 600.0,
-                    }
+                    QuotaDiscrepancy(
+                        fileset="shorty",
+                        type="files",
+                        attribute_value=500,
+                        fileset_value=600,
+                    )
                 ],
             ),
             # Case 4: Both storage and files quota discrepancies
@@ -1139,13 +1141,18 @@ class TestCheckQuotaConsistency:
                 600.0,
                 "shorty",
                 [
-                    {
-                        "shortname": "shorty",
-                        "attribute_storage_quota": 1,
-                        "fileset_storage_quota": 2.0,
-                        "attribute_files_quota": 500,
-                        "fileset_files_quota": 600.0,
-                    }
+                    QuotaDiscrepancy(
+                        fileset="shorty",
+                        type="storage",
+                        attribute_value=1,
+                        fileset_value=2,
+                    ),
+                    QuotaDiscrepancy(
+                        fileset="shorty",
+                        type="files",
+                        attribute_value=500,
+                        fileset_value=600,
+                    ),
                 ],
             ),
             # Case 5: Allocation not found in GPFS


### PR DESCRIPTION
# Description

Following changes are included in this PR:

- Adds a `send_email=True` argument to several consistency checks with send notifications
- Update the log message to accommodate the case when `send_email=False`
- Include unit tests to cover cases when `send_email=False`
- Include a `QuotaConsistencyCheckResult` dataclass for the results of quota consistency checks

Fixes #415

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [x] All tests pass (eg. `python -m pytest`)
- [x] The documentation builds and looks OK (eg. `python -m sphinx -b html docs docs/build`)
- [x] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
