### PR TITLE
Exponential Back-off Retry for fileset creation

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -18,6 +18,10 @@ asgiref==3.7.2
     #   django-stubs
 attrs==24.3.0
     # via pytest-mypy
+backoff==2.2.1
+    # via
+    #   -c requirements.txt
+    #   imperial_coldfront_plugin (pyproject.toml)
 beautifulsoup4==4.14.3
     # via imperial_coldfront_plugin (pyproject.toml)
 bibtexparser==1.4.1

--- a/imperial_coldfront_plugin/gpfs_client.py
+++ b/imperial_coldfront_plugin/gpfs_client.py
@@ -282,7 +282,8 @@ class GPFSClient(Consumer):
             )
             return response
         except requests.HTTPError as e:
-            message = e.response.json().get("status", dict()).get("message", "")
+            response_json = e.response.json()
+            message = response_json.get("status", dict()).get("message", "")
             if UNKNOWN_GROUP_MESSAGE_REGEX.match(message):
                 raise UnknownGroupDuringFilesetCreation(
                     "While creating the fileset, GPFS was not able to find the owning "
@@ -291,7 +292,7 @@ class GPFSClient(Consumer):
                     "and Active Directory."
                 ) from e
             raise FilesetCreationError(
-                f"Error creating fileset '{fileset_name}' - {e.response.json()}"
+                f"Error creating fileset '{fileset_name}' - {response_json}"
             ) from e
         except ErrorWhenProcessingJob as e:
             raise FilesetCreationError(

--- a/imperial_coldfront_plugin/gpfs_client.py
+++ b/imperial_coldfront_plugin/gpfs_client.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, TypedDict
 
+import backoff
 import requests
 from django.conf import settings
 from uplink import (
@@ -764,7 +765,14 @@ def create_fileset_set_quota(
         f"Creating fileset '{fileset_path_info.fileset_name}' at "
         f"'{fileset_path_info.fileset_absolute_path}'."
     )
-    client.create_fileset(
+
+    create_fileset_with_exponential_backoff = backoff.on_exception(
+        backoff.expo,
+        UnknownGroupDuringFilesetCreation,
+        max_time=settings.GPFS_AD_SYNC_TIMEOUT_SECONDS,
+    )(client.create_fileset)
+
+    create_fileset_with_exponential_backoff(
         fileset_path_info.filesystem_name,
         fileset_path_info.fileset_name,
         owner_id,

--- a/imperial_coldfront_plugin/gpfs_client.py
+++ b/imperial_coldfront_plugin/gpfs_client.py
@@ -1,6 +1,7 @@
 """Interface for interacting with the GPFS API."""
 
 import logging
+import re
 from collections.abc import Callable, Generator
 from dataclasses import dataclass
 from pathlib import Path
@@ -27,6 +28,11 @@ from uplink.retry.when import RetryPredicate, status_5xx
 
 from .acl import ACL
 
+UNKNOWN_GROUP_MESSAGE_REGEX = re.compile(
+    r'Input validation failed: EFSSP0010C CLI parser: The object "\S+" '
+    'specified for "group" does not exist.'
+)
+
 
 class ErrorWhenProcessingJob(Exception):
     """Handles errors in asynchronous jobs."""
@@ -42,6 +48,10 @@ class JobResponseData(TypedDict):
     status: str
     jobId: str
     result: dict[str, str]
+
+
+class UnknownGroupDuringFilesetCreation(Exception):
+    """Raised when an unknown group is specified during fileset creation."""
 
 
 class JobRunning(RetryPredicate):
@@ -271,6 +281,14 @@ class GPFSClient(Consumer):
             )
             return response
         except requests.HTTPError as e:
+            message = e.response.json().get("status", dict()).get("message", "")
+            if UNKNOWN_GROUP_MESSAGE_REGEX.match(message):
+                raise UnknownGroupDuringFilesetCreation(
+                    "While creating the fileset, GPFS was not able to find the owning"
+                    "group in Active Directory. This may be because the group has not "
+                    "yet been created or due to synchronisation issues between GPFS "
+                    "and Active Directory."
+                ) from e
             raise FilesetCreationError(
                 f"Error creating fileset '{fileset_name}' - {e.response.json()}"
             ) from e

--- a/imperial_coldfront_plugin/gpfs_client.py
+++ b/imperial_coldfront_plugin/gpfs_client.py
@@ -285,7 +285,7 @@ class GPFSClient(Consumer):
             message = e.response.json().get("status", dict()).get("message", "")
             if UNKNOWN_GROUP_MESSAGE_REGEX.match(message):
                 raise UnknownGroupDuringFilesetCreation(
-                    "While creating the fileset, GPFS was not able to find the owning"
+                    "While creating the fileset, GPFS was not able to find the owning "
                     "group in Active Directory. This may be because the group has not "
                     "yet been created or due to synchronisation issues between GPFS "
                     "and Active Directory."

--- a/imperial_coldfront_plugin/settings.py
+++ b/imperial_coldfront_plugin/settings.py
@@ -189,8 +189,8 @@ DEPARTMENTS_IN_FACULTY = {
     "fons": ["physics", "chemistry"],
 }
 
-GPFS_ALLOCATION_CREATION_SLEEP = ENV.int("GPFS_ALLOCATION_CREATION_SLEEP", default=30)
-"""Number of seconds to sleep before creating a GPFS fileset."""
+GPFS_AD_SYNC_TIMEOUT_SECONDS = ENV.int("GPFS_AD_SYNC_TIMEOUT_SECONDS", default=600)
+"""Maximum wait time configured for exponential backoff retries for fileset creation."""
 
 RDF_ALLOCATION_EXPIRY_UNLINK_DAYS = 7
 """Number of days after an allocation expires to unlink from project."""

--- a/imperial_coldfront_plugin/tasks.py
+++ b/imperial_coldfront_plugin/tasks.py
@@ -1,7 +1,6 @@
 """Plugin tasks."""
 
 import logging
-import time
 from datetime import date, timedelta
 
 from coldfront.core.allocation.models import (
@@ -206,8 +205,6 @@ def create_rdf_allocation(form_data: AllocationFormData, authoriser: str = "") -
             value=fileset_path_info.fileset_absolute_path,
         )
         if settings.GPFS_ENABLED:
-            # Wait to make sure that GFPS server has picked up changes in AD
-            time.sleep(settings.GPFS_ALLOCATION_CREATION_SLEEP)
             try:
                 logger.info(
                     "Creating GPFS fileset and setting quota for "

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
     "uplink",
     "ldap3",
     "pint",
+    "backoff",
 ]
 
 [project.optional-dependencies]

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,8 @@ asgiref==3.7.2
     #   coldfront
     #   django
     #   django-simple-history
+backoff==2.2.1
+    # via imperial_coldfront_plugin (pyproject.toml)
 bibtexparser==1.4.1
     # via
     #   coldfront

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -111,7 +111,6 @@ def pytest_configure():
             GID_RANGES=dict(
                 rdf=[range(1031386, 1031405)], hx2=[range(1031406, 1031425)]
             ),
-            GPFS_ALLOCATION_CREATION_SLEEP=0,
             ENABLE_RDF_ALLOCATION_LIFECYCLE=True,
             ENABLE_USER_GROUP_CREATION=True,
             RDF_ASK_TICKET_URL="http://example.com/ticket",

--- a/tests/test_gpfs.py
+++ b/tests/test_gpfs.py
@@ -220,6 +220,33 @@ def test_create_fileset_set_quota_existing_directory(
     )
 
 
+def test_create_fileset_set_quota_backoff(client_mock, fileset_path_info, settings):
+    """Test client.create_fileset retries on UnknownGroupDuringFilesetCreation."""
+    # __name__ used by the backoff library logging so needs to exist on the mock
+    client_mock.create_fileset.__name__ = "create_fileset"
+    # 2 errors then a success
+    client_mock.create_fileset.side_effect = [
+        UnknownGroupDuringFilesetCreation("Transient error"),
+        UnknownGroupDuringFilesetCreation("Transient error"),
+        None,
+    ]
+
+    create_fileset_set_quota(
+        fileset_path_info,
+        OWNER_ID,
+        GROUP_ID,
+        settings.GPFS_FILESET_POSIX_PERMISSIONS,
+        settings.GPFS_FILESET_ACL,
+        settings.GPFS_PARENT_DIRECTORY_POSIX_PERMISSIONS,
+        settings.GPFS_PARENT_DIRECTORY_ACL,
+        BLOCK_QUOTA,
+        FILES_QUOTA,
+    )
+
+    # check the method wrapped by backoff was called three times
+    assert len(client_mock.create_fileset.call_args_list) == 3
+
+
 def make_response(data: dict[str, object]) -> Mock:
     """Helper to make a mock response with .json() method."""
     response_mock = Mock()

--- a/tests/test_gpfs.py
+++ b/tests/test_gpfs.py
@@ -3,11 +3,15 @@ from pathlib import Path
 from unittest.mock import Mock, call
 
 import pytest
+import requests
 
 from imperial_coldfront_plugin.gpfs_client import (
     DirectoryExistsError,
+    ErrorWhenProcessingJob,
+    FilesetCreationError,
     FilesetPathInfo,
     GPFSClient,
+    UnknownGroupDuringFilesetCreation,
     create_fileset_set_quota,
 )
 
@@ -19,7 +23,7 @@ DEPARTMENT = "compsci"
 GROUP_NAME = "mygroup"
 FILESET_NAME = "myfileset"
 OWNER_ID = "someowner"
-GROUP_ID = "rdf-somegroup"
+GROUP_ID = r"IC\\rdf-somegroup"
 BLOCK_QUOTA = "123456T"
 FILES_QUOTA = "654321T"
 PERMISSIONS = "755"
@@ -443,38 +447,119 @@ def test__create_fileset(completed_job_status, request_mock):
     )
 
 
-def test_create_fileset(mocker):
-    """Test that create_fileset wrapper works correctly."""
-    client = GPFSClient()
-    _create_fileset_mock = mocker.patch.object(
-        client, "_create_fileset", autospec=True, return_value=None
-    )
+class TestCreateFileset:
+    """Test the create_fileset wrapper method."""
 
-    response = client.create_fileset(
-        filesystem_name=FILESYSTEM_NAME,
-        fileset_name=FILESET_NAME,
-        owner_id=OWNER_ID,
-        group_id=GROUP_ID,
-        path=(
-            f"{FILESYSTEM_MOUNT_PATH}/{TOP_LEVEL_DIRECTORIES}/{FACULTY}/"
-            f"{DEPARTMENT}/{GROUP_NAME}/{FILESET_NAME}"
-        ),
-        permissions=PERMISSIONS,
-        parent_fileset=PARENT_FILESET,
+    FILESET_PATH = (
+        f"{FILESYSTEM_MOUNT_PATH}/{TOP_LEVEL_DIRECTORIES}/{FACULTY}/"
+        f"{DEPARTMENT}/{GROUP_NAME}/{FILESET_NAME}"
     )
+    """Absolute path to the fileset for use in tests."""
 
-    _create_fileset_mock.assert_called_once_with(
-        filesystemName=FILESYSTEM_NAME,
-        filesetName=FILESET_NAME,
-        owner=f"{OWNER_ID}:{GROUP_ID}",
-        path=f"{FILESYSTEM_MOUNT_PATH}/{TOP_LEVEL_DIRECTORIES}/{FACULTY}/{DEPARTMENT}/{GROUP_NAME}/{FILESET_NAME}",
-        permissions=PERMISSIONS,
-        inodeSpace=PARENT_FILESET,
-        permissionChangeMode="chmodAndSetAcl",
-        iamMode="advisory",
-    )
+    @pytest.fixture
+    def client(self):
+        """Fixture for a GPFSClient instance."""
+        return GPFSClient()
 
-    assert response is None
+    @pytest.fixture
+    def _create_fileset_mock(self, mocker, client):
+        """Fixture for mocking the _create_fileset method."""
+        return mocker.patch.object(client, "_create_fileset", autospec=True)
+
+    def test_success(self, client, _create_fileset_mock):
+        """Test that create_fileset wrapper works correctly."""
+        return_value = "return_value"
+        _create_fileset_mock.return_value = return_value
+
+        response = client.create_fileset(
+            filesystem_name=FILESYSTEM_NAME,
+            fileset_name=FILESET_NAME,
+            owner_id=OWNER_ID,
+            group_id=GROUP_ID,
+            path=self.FILESET_PATH,
+            permissions=PERMISSIONS,
+            parent_fileset=PARENT_FILESET,
+        )
+
+        _create_fileset_mock.assert_called_once_with(
+            filesystemName=FILESYSTEM_NAME,
+            filesetName=FILESET_NAME,
+            owner=f"{OWNER_ID}:{GROUP_ID}",
+            path=self.FILESET_PATH,
+            permissions=PERMISSIONS,
+            inodeSpace=PARENT_FILESET,
+            permissionChangeMode="chmodAndSetAcl",
+            iamMode="advisory",
+        )
+
+        assert response is return_value
+
+    def test_http_error(self, client, _create_fileset_mock):
+        """Test that create_fileset wrapper raises an error on HTTP error."""
+        response_json = dict(message="error_text")
+        _create_fileset_mock.side_effect = requests.HTTPError(
+            "HTTP error",
+            response=make_response(response_json),
+        )
+
+        with pytest.raises(
+            FilesetCreationError,
+            match=str(response_json),
+        ):
+            client.create_fileset(
+                filesystem_name=FILESYSTEM_NAME,
+                fileset_name=FILESET_NAME,
+                owner_id=OWNER_ID,
+                group_id=GROUP_ID,
+                path=self.FILESET_PATH,
+                permissions=PERMISSIONS,
+                parent_fileset=PARENT_FILESET,
+            )
+
+    def test_unknown_group_error(self, client, _create_fileset_mock):
+        """Test that create_fileset wrapper raises an error on unknown group."""
+        error_message = (
+            "Input validation failed: EFSSP0010C CLI parser: "
+            f'The object "{GROUP_ID}" specified for "group" does not exist.'
+        )
+        response_json = dict(status=dict(message=error_message))
+        _create_fileset_mock.side_effect = requests.HTTPError(
+            "HTTP error",
+            response=make_response(response_json),
+        )
+
+        with pytest.raises(
+            UnknownGroupDuringFilesetCreation,
+            match="While creating the fileset, GPFS was not able to find the owning",
+        ):
+            client.create_fileset(
+                filesystem_name=FILESYSTEM_NAME,
+                fileset_name=FILESET_NAME,
+                owner_id=OWNER_ID,
+                group_id=GROUP_ID,
+                path=self.FILESET_PATH,
+                permissions=PERMISSIONS,
+                parent_fileset=PARENT_FILESET,
+            )
+
+    def test_processing_error(self, client, _create_fileset_mock):
+        """Test that create_fileset wrapper raises an error on processing error."""
+        error_content = "Processing error"
+        _create_fileset_mock.side_effect = ErrorWhenProcessingJob(error_content)
+
+        with pytest.raises(FilesetCreationError, match=error_content):
+            client.create_fileset(
+                filesystem_name=FILESYSTEM_NAME,
+                fileset_name=FILESET_NAME,
+                owner_id=OWNER_ID,
+                group_id=GROUP_ID,
+                path=(
+                    f"{FILESYSTEM_MOUNT_PATH}/{TOP_LEVEL_DIRECTORIES}/{FACULTY}/"
+                    f"{DEPARTMENT}/{GROUP_NAME}/{FILESET_NAME}"
+                ),
+                permissions=PERMISSIONS,
+                parent_fileset=PARENT_FILESET,
+            )
 
 
 def test__set_quota(completed_job_status, request_mock):


### PR DESCRIPTION
# Description

This PR removes the previous arbitrary length sleep before attempting fileset creation. Instead it implements an exponential backoff retry scheme using the `backoff` library with a configurable maximum timeout.

Fixes #417 

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [ ] All tests pass (eg. `python -m pytest`)
- [ ] The documentation builds and looks OK (eg. `python -m sphinx -b html docs docs/build`)
- [ ] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
