### PR TITLE
Ldap consistency

### DIFF
--- a/imperial_coldfront_plugin/emails.py
+++ b/imperial_coldfront_plugin/emails.py
@@ -30,11 +30,16 @@ class DiscrepancyCheckResult:
 
     membership_discrepancies: list[Discrepancy]
     missing_ldap_groups: list[str]
+    additional_ldap_groups: list[str]
 
     @property
     def discrepancies_found(self) -> bool:
         """Whether any discrepancies were found."""
-        return bool(self.membership_discrepancies or self.missing_ldap_groups)
+        return bool(
+            self.membership_discrepancies
+            or self.missing_ldap_groups
+            or self.additional_ldap_groups
+        )
 
 
 @dataclass
@@ -97,6 +102,11 @@ def send_discrepancy_notification(
     if check_result.missing_ldap_groups:
         message += f"\n{source} allocations that do not have corresponding AD group:\n"
         for group in sorted(check_result.missing_ldap_groups):
+            message += f"\t- {group}\n"
+
+    if check_result.additional_ldap_groups:
+        message += f"\nAD groups with no corresponding {source} allocation:\n"
+        for group in sorted(check_result.additional_ldap_groups):
             message += f"\t- {group}\n"
 
     mail_admins(

--- a/imperial_coldfront_plugin/settings.py
+++ b/imperial_coldfront_plugin/settings.py
@@ -246,3 +246,8 @@ ENABLE_RDF_ALLOCATION_AUTO_CREDIT = ENV.bool(
 
 CREDITS_HELP_URL = ENV.str("CREDITS_HELP_URL", default="")
 """URL of the help page for credits."""
+
+LDAP_SUPPRESS_ADDITIONAL_GROUPS = ENV.list(
+    "LDAP_SUPPRESS_ADDITIONAL_GROUPS", default=[]
+)
+"""LDAP groups excluded from additional-group consistency check alerts."""

--- a/imperial_coldfront_plugin/tasks.py
+++ b/imperial_coldfront_plugin/tasks.py
@@ -240,8 +240,10 @@ def find_discrepancies_helper(
     """Finds discrepancies between LDAP groups and allocation users."""
     discrepancies: list[Discrepancy] = []
     missing_ldap_groups = []
+    expected_group_names = set()
     for allocation in allocations:
         group_name = allocation.ldap_shortname
+        expected_group_names.add(group_name)
 
         active_users = AllocationUser.objects.filter(
             allocation=allocation, status__name="Active"
@@ -265,8 +267,15 @@ def find_discrepancies_helper(
                     extra_members=list(extra_members),
                 )
             )
+    additional_ldap_groups = sorted(
+        set(ldap_groups)
+        - expected_group_names
+        - set(settings.LDAP_SUPPRESS_ADDITIONAL_GROUPS)
+    )
     return DiscrepancyCheckResult(
-        membership_discrepancies=discrepancies, missing_ldap_groups=missing_ldap_groups
+        membership_discrepancies=discrepancies,
+        missing_ldap_groups=missing_ldap_groups,
+        additional_ldap_groups=additional_ldap_groups,
     )
 
 

--- a/tests/test_emails.py
+++ b/tests/test_emails.py
@@ -115,6 +115,7 @@ message = Template(
     "\n\n"
     "$membership_discrepancies_text"
     "$missing_ldap_groups_text"
+    "$additional_ldap_groups_text"
 )
 
 
@@ -131,6 +132,7 @@ def test_send_discrepancy_notification_membership_discrepancies(source: str):
             )
         ],
         missing_ldap_groups=[],
+        additional_ldap_groups=[],
     )
 
     membership_discrepancies_text = (
@@ -149,6 +151,7 @@ def test_send_discrepancy_notification_membership_discrepancies(source: str):
         source=source,
         membership_discrepancies_text=membership_discrepancies_text,
         missing_ldap_groups_text="",
+        additional_ldap_groups_text="",
     )
 
 
@@ -158,6 +161,7 @@ def test_send_discrepancy_notification_missing_ldap_groups(source: str):
     check_result = DiscrepancyCheckResult(
         membership_discrepancies=[],
         missing_ldap_groups=["rdfdev-testgroup"],
+        additional_ldap_groups=[],
     )
     missing_ldap_groups_text = (
         f"\n{source} allocations that do not have corresponding AD group:\n"
@@ -171,6 +175,31 @@ def test_send_discrepancy_notification_missing_ldap_groups(source: str):
         source=source,
         membership_discrepancies_text="",
         missing_ldap_groups_text=missing_ldap_groups_text,
+        additional_ldap_groups_text="",
+    )
+
+
+@pytest.mark.parametrize("source", ["RDF", "HX2"])
+def test_send_discrepancy_notification_additional_ldap_groups(source: str):
+    """Test that the discrepancy email includes additional LDAP groups."""
+    check_result = DiscrepancyCheckResult(
+        membership_discrepancies=[],
+        missing_ldap_groups=[],
+        additional_ldap_groups=["rdfdev-additional"],
+    )
+    additional_ldap_groups_text = (
+        f"\nAD groups with no corresponding {source} allocation:\n"
+        "\t- rdfdev-additional\n"
+    )
+
+    send_discrepancy_notification(check_result, source=source)
+
+    assert len(mail.outbox) == 1
+    assert mail.outbox[0].body == message.substitute(
+        source=source,
+        membership_discrepancies_text="",
+        missing_ldap_groups_text="",
+        additional_ldap_groups_text=additional_ldap_groups_text,
     )
 
 

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -492,7 +492,51 @@ class TestCheckRDFLdapConsistency:
 
         result = check_rdf_ldap_consistency()
 
-        assert result == DiscrepancyCheckResult([], [])
+        assert result == DiscrepancyCheckResult([], [], [])
+        notify_mock.assert_not_called()
+
+    def test_additional_ldap_group(
+        self,
+        rdf_allocation,
+        rdf_allocation_user,
+        ldap_group_search_mock,
+        notify_mock,
+        rdf_allocation_ldap_name,
+    ):
+        """Test that a group with no corresponding allocation is reported."""
+        additional_group = "rdfdev-additional"
+        username = rdf_allocation_user.user.username
+        ldap_group_search_mock.return_value = {
+            rdf_allocation_ldap_name: [username],
+            additional_group: [],
+        }
+
+        result = check_rdf_ldap_consistency()
+
+        assert result == DiscrepancyCheckResult([], [], [additional_group])
+        notify_mock.assert_called_once_with(result, source="RDF")
+
+    def test_suppressed_additional_ldap_group(
+        self,
+        rdf_allocation,
+        rdf_allocation_user,
+        ldap_group_search_mock,
+        notify_mock,
+        rdf_allocation_ldap_name,
+        settings,
+    ):
+        """Test that configured additional LDAP groups are ignored."""
+        additional_group = "rdfdev-additional"
+        settings.LDAP_SUPPRESS_ADDITIONAL_GROUPS = [additional_group]
+        username = rdf_allocation_user.user.username
+        ldap_group_search_mock.return_value = {
+            rdf_allocation_ldap_name: [username],
+            additional_group: [],
+        }
+
+        result = check_rdf_ldap_consistency()
+
+        assert result == DiscrepancyCheckResult([], [], [])
         notify_mock.assert_not_called()
 
     def test_missing_members(
@@ -558,7 +602,7 @@ class TestCheckRDFLdapConsistency:
 
         result = check_rdf_ldap_consistency()
 
-        assert result == DiscrepancyCheckResult([], [rdf_allocation_ldap_name])
+        assert result == DiscrepancyCheckResult([], [rdf_allocation_ldap_name], [])
         notify_mock.assert_called_once_with(result, source="RDF")
 
     def test_no_email_when_send_email_false(
@@ -603,7 +647,7 @@ class TestCheckHX2LdapConsistency:
 
         result = check_hx2_ldap_consistency()
 
-        assert result == DiscrepancyCheckResult([], [])
+        assert result == DiscrepancyCheckResult([], [], [])
         notify_mock.assert_not_called()
 
     def test_missing_members(
@@ -666,7 +710,7 @@ class TestCheckHX2LdapConsistency:
 
         result = check_hx2_ldap_consistency()
 
-        assert result == DiscrepancyCheckResult([], [hx2_allocation.ldap_shortname])
+        assert result == DiscrepancyCheckResult([], [hx2_allocation.ldap_shortname], [])
         notify_mock.assert_called_once_with(result, source="HX2")
 
     def test_no_email_when_send_email_false(


### PR DESCRIPTION
# Description
I have added an additional check to the `discrepancies_found` function to flag ldap groups that do not exist in coldfront allocations and send an email alert. 
Fixes #413 

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [ ] All tests pass (eg. `python -m pytest`)
- [ ] The documentation builds and looks OK (eg. `python -m sphinx -b html docs docs/build`)
- [ ] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
